### PR TITLE
Fixed old reference to LIB_GT511C3.h

### DIFF
--- a/examples/FPS_Enroll.ino
+++ b/examples/FPS_Enroll.ino
@@ -7,7 +7,7 @@
 */
 
 
-#include "LIB_GT511C3.h"
+#include "FPS_GT511C3.h"
 #include "SoftwareSerial.h"
 
 // Hardware setup - FPS connected to:


### PR DESCRIPTION
Fixed old reference to LIB_GT511C3.h (original name for the library)
