### PR TITLE
Fixed empty enrollment id finder

### DIFF
--- a/examples/FPS_Enroll.ino
+++ b/examples/FPS_Enroll.ino
@@ -38,7 +38,7 @@ void Enroll()
 	while (okid == false)
 	{
 		okid = fps.CheckEnrolled(enrollid);
-		if (okid==false) okid++;
+		if (okid==false) enrollid++;
 	}
 	fps.EnrollStart(enrollid);
 


### PR DESCRIPTION
if (okid==false) okid++;
this code will just change the bool to true. not what was intended. it is supposed to increment the value of enrollid.
