### PR TITLE
Auto ID selection logic error

### DIFF
--- a/FPS_GT511C3/Examples/FPS_Enroll/FPS_Enroll.ino
+++ b/FPS_GT511C3/Examples/FPS_Enroll/FPS_Enroll.ino
@@ -34,11 +34,11 @@ void Enroll()
 
 	// find open enroll id
 	int enrollid = 0;
-	bool okid = true;
-	while (okid == true)
+	bool usedid = true;
+	while (usedid == true)
 	{
-		okid = fps.CheckEnrolled(enrollid);
-		if (okid==true) enrollid++;
+		usedid = fps.CheckEnrolled(enrollid);
+		if (usedid == true) enrollid++;
 	}
 	fps.EnrollStart(enrollid);
 


### PR DESCRIPTION
Fixed minor logic error with automatically selecting the next open ID number.

This:
if (okid==false) enrollid++;

Changed to this:
if (okid==true) enrollid++;
