### PR TITLE
Update FPS_Enroll.ino

### DIFF
--- a/FPS_GT511C3/Examples/FPS_Enroll/FPS_Enroll.ino
+++ b/FPS_GT511C3/Examples/FPS_Enroll/FPS_Enroll.ino
@@ -38,7 +38,8 @@ void Enroll()
 	while (okid == false)
 	{
 		okid = fps.CheckEnrolled(enrollid);
-		if (okid==false) enrollid++;
+		if (okid==true) enrollid++;
+		else break;
 	}
 	fps.EnrollStart(enrollid);
 


### PR DESCRIPTION
Example will get stuck with the older version. If the number has not been enrolled, it should be used.
