### PR TITLE
Adding listener to change and return to activate the sensor

### DIFF
--- a/FPS_GT511C3/FPS_GT511C3.cpp
+++ b/FPS_GT511C3/FPS_GT511C3.cpp
@@ -542,6 +542,12 @@ bool FPS_GT511C3::DeleteAll()
 	return retval;
 }
 
+void FPS_GT511C3::listen()
+{
+	if (UseSerialDebug) Serial.println("FPS - listen the serial port");
+	_serial.listen();
+}
+
 // Checks the currently pressed finger against a specific ID
 // Parameter: 0-199 (id number to be checked)
 // Returns:

--- a/FPS_GT511C3/FPS_GT511C3.h
+++ b/FPS_GT511C3/FPS_GT511C3.h
@@ -336,6 +336,8 @@ class FPS_GT511C3
 	// may revisit this if I find a need for it
 	//Data_Packet GetNextDataPacket();
 
+	void listen();
+
 private:
 	 void SendCommand(byte cmd[], int length);
 	 Response_Packet* GetResponse();

--- a/FPS_GT511C3/keywords.txt
+++ b/FPS_GT511C3/keywords.txt
@@ -16,3 +16,4 @@ DeleteAll	KEYWORD2
 Verify1_1	KEYWORD2
 Identify1_N	KEYWORD2
 CaptureFinger	KEYWORD2
+listen	KEYWORD2


### PR DESCRIPTION
Having more than 1 serial communication (UARL), it is not possible to switch between one and the other to listen to one and then the other.
Is added a function that only calls lisent of the serial port _serial