### PR TITLE
Fix warnings

### DIFF
--- a/FPS_GT511C3/FPS_GT511C3.cpp
+++ b/FPS_GT511C3/FPS_GT511C3.cpp
@@ -6,9 +6,11 @@
 	TLDR; Wil Wheaton's Law
 */
 
-#include "FPS_GT511C3.h";
+#include "FPS_GT511C3.h"
 
+#ifndef __GNUC__
 #pragma region -= Command_Packet Definitions =-
+#endif  //__GNUC__
 
 // returns the 12 bytes of the generated command packet
 // remember to call delete on the returned array
@@ -80,9 +82,13 @@ word Command_Packet::_CalculateChecksum()
 Command_Packet::Command_Packet()
 {
 };
+#ifndef __GNUC__
 #pragma endregion
+#endif  //__GNUC__
 
+#ifndef __GNUC__
 #pragma region -= Response_Packet Definitions =-
+#endif  //__GNUC__
 // creates and parses a response packet from the finger print scanner
 Response_Packet::Response_Packet(byte* buffer, bool UseSerialDebug)
 {
@@ -186,7 +192,7 @@ byte Response_Packet::GetLowByte(word w)
 }
 
 // checks to see if the byte is the proper value, and logs it to the serial channel if not
-bool Response_Packet::CheckParsing(byte b, byte propervalue, byte alternatevalue, char* varname, bool UseSerialDebug)
+bool Response_Packet::CheckParsing(byte b, byte propervalue, byte alternatevalue, const char* varname, bool UseSerialDebug)
 {
 	bool retval = (b != propervalue) && (b != alternatevalue);
 	if ((UseSerialDebug) && (retval))
@@ -200,21 +206,31 @@ bool Response_Packet::CheckParsing(byte b, byte propervalue, byte alternatevalue
 		Serial.print(" != ");
 		Serial.println(b, HEX);
 	}
-
+  return retval;
 }
+#ifndef __GNUC__
 #pragma endregion
+#endif  //__GNUC__
 
+#ifndef __GNUC__
 #pragma region -= Data_Packet =-
+#endif  //__GNUC__
 //void Data_Packet::StartNewPacket()
 //{
 //	Data_Packet::NextPacketID = 0;
 //	Data_Packet::CheckSum = 0;
 //}
+#ifndef __GNUC__
 #pragma endregion
+#endif  //__GNUC__
 
+#ifndef __GNUC__
 #pragma region -= FPS_GT511C3 Definitions =-
+#endif  //__GNUC__
 
+#ifndef __GNUC__
 #pragma region -= Constructor/Destructor =-
+#endif  //__GNUC__
 // Creates a new object to interface with the fingerprint scanner
 FPS_GT511C3::FPS_GT511C3(uint8_t rx, uint8_t tx)
 	: _serial(rx,tx)
@@ -230,9 +246,13 @@ FPS_GT511C3::~FPS_GT511C3()
 {
 	_serial.~SoftwareSerial();
 }
+#ifndef __GNUC__
 #pragma endregion
+#endif  //__GNUC__
 
+#ifndef __GNUC__
 #pragma region -= Device Commands =-
+#endif  //__GNUC__
 //Initialises the device and gets ready for commands
 void FPS_GT511C3::Open()
 {
@@ -305,7 +325,7 @@ bool FPS_GT511C3::SetLED(bool on)
 // Parameter: 9600, 19200, 38400, 57600, 115200
 // Returns: True if success, false if invalid baud
 // NOTE: Untested (don't have a logic level changer and a voltage divider is too slow)
-bool FPS_GT511C3::ChangeBaudRate(int baud)
+bool FPS_GT511C3::ChangeBaudRate(unsigned long baud)
 {
 	if ((baud == 9600) || (baud == 19200) || (baud == 38400) || (baud == 57600) || (baud == 115200))
 	{
@@ -619,9 +639,13 @@ bool FPS_GT511C3::CaptureFinger(bool highquality)
 	return retval;
 
 }
+#ifndef __GNUC__
 #pragma endregion
+#endif  //__GNUC__
 
+#ifndef __GNUC__
 #pragma region -= Not imlemented commands =-
+#endif  //__GNUC__
 // Gets an image that is 258x202 (52116 bytes) and returns it in 407 Data_Packets
 // Use StartDataDownload, and then GetNextDataPacket until done
 // Returns: True (device confirming download starting)
@@ -709,10 +733,14 @@ bool FPS_GT511C3::CaptureFinger(bool highquality)
 // UpgradeISOCDImage - Data sheet says not supported
 // SetIAPMode - for upgrading firmware (which data sheet says is not supported)
 // Ack and Nack	are listed as commands for some unknown reason... not implemented
+#ifndef __GNUC__
 #pragma endregion
+#endif  //__GNUC__
 
 
+#ifndef __GNUC__
 #pragma region -= Private Methods =-
+#endif  //__GNUC__
 // Sends the command to the software serial channel
 void FPS_GT511C3::SendCommand(byte cmd[], int length)
 {
@@ -778,7 +806,11 @@ void FPS_GT511C3::serialPrintHex(byte data)
   sprintf(tmp, "%.2X",data);
   Serial.print(tmp);
 }
+#ifndef __GNUC__
 #pragma endregion
+#endif  //__GNUC__
 
+#ifndef __GNUC__
 #pragma endregion
+#endif  //__GNUC__
 

--- a/FPS_GT511C3/FPS_GT511C3.h
+++ b/FPS_GT511C3/FPS_GT511C3.h
@@ -9,9 +9,11 @@
 #ifndef FPS_GT511C3_h
 #define FPS_GT511C3_h
 
-#include "Arduino.h";
-#include "SoftwareSerial.h";
+#include "Arduino.h"
+#include "SoftwareSerial.h"
+#ifndef __GNUC__
 #pragma region -= Command_Packet =-
+#endif  //__GNUC__
 /*
 	Command_Packet represents the 12 byte command that we send to the finger print scanner
 */
@@ -76,9 +78,13 @@ class Command_Packet
 		byte GetHighByte(word w);						
 		byte GetLowByte(word w);
 };
+#ifndef __GNUC__
 #pragma endregion
+#endif  //__GNUC__
 
+#ifndef __GNUC__
 #pragma region -= Response_Packet =-
+#endif  //__GNUC__
 /*
 	Response_Packet represents the returned data from the finger print scanner 
 */
@@ -127,14 +133,18 @@ class Response_Packet
 		int IntFromParameter();
 
 	private: 
-		bool CheckParsing(byte b, byte propervalue, byte alternatevalue, char* varname, bool UseSerialDebug);
+		bool CheckParsing(byte b, byte propervalue, byte alternatevalue, const char* varname, bool UseSerialDebug);
 		word CalculateChecksum(byte* buffer, int length);
 		byte GetHighByte(word w);						
 		byte GetLowByte(word w);
 };
+#ifndef __GNUC__
 #pragma endregion
+#endif  //__GNUC__
 
+#ifndef __GNUC__
 #pragma region -= Data_Packet =- 
+#endif  //__GNUC__
 // Data Mule packet for receiving large data(in 128 byte pieces) from the FPS
 // This class can only transmit one packet at a time
 //class Data_Packet
@@ -149,7 +159,9 @@ class Response_Packet
 //private:
 //	static int NextPacketID;
 //};
+#ifndef __GNUC__
 #pragma endregion
+#endif  //__GNUC__
 
 
 /*
@@ -162,16 +174,22 @@ class FPS_GT511C3
 	// Enables verbose debug output using hardware Serial 
 	bool UseSerialDebug;
 
+#ifndef __GNUC__
 	#pragma region -= Constructor/Destructor =-
+#endif  //__GNUC__
 	// Creates a new object to interface with the fingerprint scanner
 	FPS_GT511C3(uint8_t rx, uint8_t tx);
 	
 	// destructor
 	~FPS_GT511C3();
+#ifndef __GNUC__
 	#pragma endregion
+#endif  //__GNUC__
 
 
+#ifndef __GNUC__
 	#pragma region -= Device Commands =-
+#endif  //__GNUC__
 	//Initialises the device and gets ready for commands
 	void Open();
 
@@ -189,7 +207,7 @@ class FPS_GT511C3
 	// Parameter: 9600 - 115200
 	// Returns: True if success, false if invalid baud
 	// NOTE: Untested (don't have a logic level changer and a voltage divider is too slow)
-	bool ChangeBaudRate(int baud);
+	bool ChangeBaudRate(unsigned long baud);
 
 	// Gets the number of enrolled fingerprints
 	// Return: The total number of enrolled fingerprints
@@ -266,9 +284,13 @@ class FPS_GT511C3
 	// Generally, use high quality for enrollment, and low quality for verification/identification
 	// Returns: True if ok, false if no finger pressed
 	bool CaptureFinger(bool highquality);
+#ifndef __GNUC__
 	#pragma endregion
+#endif  //__GNUC__
 
+#ifndef __GNUC__
 	#pragma region -= Not implemented commands =-
+#endif  //__GNUC__
 	// Gets an image that is 258x202 (52116 bytes) and returns it in 407 Data_Packets
 	// Use StartDataDownload, and then GetNextDataPacket until done
 	// Returns: True (device confirming download starting)
@@ -319,9 +341,13 @@ class FPS_GT511C3
 	// UpgradeISOCDImage - Data Sheet says not supported
 	// SetIAPMode - for upgrading firmware (which is not supported)
 	// Ack and Nack	are listed as a commands for some unknown reason... not implemented
-	#pragma endregion
+#ifndef __GNUC__
+  #pragma endregion
+#endif  //__GNUC__
 
+#ifndef __GNUC__
 	#pragma endregion
+#endif  //__GNUC__
 
 	void serialPrintHex(byte data);
 	void SendToSerial(byte data[], int length);


### PR DESCRIPTION
The library previously had the following warnings:
- `extra tokens at end of #include directive`
- `ignoring #pragma region`
- `deprecated conversion from string constant to 'char*'`
- `no return statement in function returning non-void`
- `comparison is always false due to limited range of data type`

Now it has none.

Adding the return to `CheckParsing()` did increase program memory usage by 4 bytes.

Note that I inferred from the variable name `retvalue` that it was intended to be returned from `CheckParsing()`. However, it seems counterintuitive that the function would return `true` when the value is incorrect and `false` when it's correct. Of course no code is currently using the return value of that function so it won't break anything either way. I'm happy to update this PR to change the logic if that's not what was intended.