### PR TITLE
Add More Comments When Using w/ GT-521F52

### DIFF
--- a/examples/FPS_Blink/FPS_Blink.ino
+++ b/examples/FPS_Blink/FPS_Blink.ino
@@ -11,7 +11,9 @@
 	This code should work with the any model of ADH-Tech's FPS as long as
 	you are within the minimum logic level threshold for the FPS serial UART.
 	This code has been tested with these models:
- 
+
+              GT-521F52 [ https://www.sparkfun.com/products/14585 ]
+              GT-521F32 [ https://www.sparkfun.com/products/14518 ]
               GT-511C3  [ https://www.sparkfun.com/products/11792 ]
               GT-511C1R [ https://www.sparkfun.com/products/13007 ]
 	
@@ -56,8 +58,8 @@ Note: You can add the two 10kOhm resistors in series for 20kOhms. =)
 // FPS (RX) is connected through a converter to pin 5 (Arduino's Software TX)
 FPS_GT511C3 fps(4, 5); // (Arduino SS_RX = pin 4, Arduino SS_TX = pin 5)
 
-/*If using another Arduino microcontroller, try commenting out line 57 and
-uncommenting line 66 due to the limitations listed in the
+/*If using another Arduino microcontroller, try commenting out line 59 and
+uncommenting line 68 due to the limitations listed in the
 library's note => https://www.arduino.cc/en/Reference/softwareSerial . Do
 not forget to rewire the connection to the Arduino*/
 

--- a/examples/FPS_Enroll/FPS_Enroll.ino
+++ b/examples/FPS_Enroll/FPS_Enroll.ino
@@ -11,7 +11,9 @@
 	This code should work with the any model of ADH-Tech's FPS as long as
 	you are within the minimum logic level threshold for the FPS serial UART.
 	This code has been tested with these models:
- 
+
+              GT-521F52 [ https://www.sparkfun.com/products/14585 ]
+              GT-521F32 [ https://www.sparkfun.com/products/14518 ]
               GT-511C3  [ https://www.sparkfun.com/products/11792 ]
               GT-511C1R [ https://www.sparkfun.com/products/13007 ]
 	      
@@ -57,8 +59,8 @@ Note: You can add the two 10kOhm resistors in series for 20kOhms. =)
 // FPS (RX) is connected through a converter to pin 5 (Arduino's Software TX)
 FPS_GT511C3 fps(4, 5); // (Arduino SS_RX = pin 4, Arduino SS_TX = pin 5)
 
-/*If using another Arduino microcontroller, try commenting out line 58 and
-uncommenting line 67 due to the limitations listed in the
+/*If using another Arduino microcontroller, try commenting out line 60 and
+uncommenting line 69 due to the limitations listed in the
 library's note => https://www.arduino.cc/en/Reference/softwareSerial . Do
 not forget to rewire the connection to the Arduino*/
 

--- a/examples/FPS_IDFinger/FPS_IDFinger.ino
+++ b/examples/FPS_IDFinger/FPS_IDFinger.ino
@@ -11,7 +11,9 @@
 	This code should work with the any model of ADH-Tech's FPS as long as
 	you are within the minimum logic level threshold for the FPS serial UART.
 	This code has been tested with these models:
- 
+
+              GT-521F52 [ https://www.sparkfun.com/products/14585 ]
+              GT-521F32 [ https://www.sparkfun.com/products/14518 ]
               GT-511C3  [ https://www.sparkfun.com/products/11792 ]
               GT-511C1R [ https://www.sparkfun.com/products/13007 ]
 
@@ -50,8 +52,8 @@ Note: You can add the two 10kOhm resistors in series for 20kOhms. =)
 // FPS (RX) is connected through a converter to pin 5 (Arduino's Software TX)
 FPS_GT511C3 fps(4, 5); // (Arduino SS_RX = pin 4, Arduino SS_TX = pin 5)
 
-/*If using another Arduino microcontroller, try commenting out line 51 and
-uncommenting line 60 due to the limitations listed in the
+/*If using another Arduino microcontroller, try commenting out line 53 and
+uncommenting line 62 due to the limitations listed in the
 library's note => https://www.arduino.cc/en/Reference/softwareSerial . Do
 not forget to rewire the connection to the Arduino*/
 
@@ -75,11 +77,13 @@ void loop()
 		fps.CaptureFinger(false);
 		int id = fps.Identify1_N();
 		
-	        /*Note : GT-511C3 can hold 200 fingerprint templates. 
-		         GT-511C1R can hold 20 fingerprint templates.
+	     /*Note:  GT-521F52 can hold 3000 fingerprint templates
+                GT-521F32 can hold 200 fingerprint templates
+                 GT-511C3 can hold 200 fingerprint templates. 
+		            GT-511C1R can hold 20 fingerprint templates.
 			 Make sure to change the id depending on what
 			 model you are using */
-		if (id <200)
+		if (id <200) //<- change id value depending model you are using
 		{//if the fingerprint matches, provide the matching template ID
 			Serial.print("Verified ID:");
 			Serial.println(id);

--- a/examples/FPS_Serial_Passthrough/FPS_Serial_Passthrough.ino
+++ b/examples/FPS_Serial_Passthrough/FPS_Serial_Passthrough.ino
@@ -10,6 +10,8 @@
  *  you are within the minimum logic level threshold for the FPS serial UART.
  *  This code has been tested with these models:
  *
+ *            GT-521F52 [ https://www.sparkfun.com/products/14585 ]
+ *            GT-521F32 [ https://www.sparkfun.com/products/14518 ]
  *            GT-511C3  [ https://www.sparkfun.com/products/11792 ]
  *            GT-511C1R [ https://www.sparkfun.com/products/13007 ]
  *
@@ -63,8 +65,8 @@ Note: You can add the two 10kOhm resistors in series for 20kOhms. =)
 // FPS (RX) is connected through a converter to pin 5 (Arduino's Software TX)
 SoftwareSerial fps(4, 5); // (Arduino SS_RX = pin 4, Arduino SS_TX = pin 5)
 
-/*If using another Arduino microcontroller, try commenting out line 64 and
-uncommenting line 73 due to the limitations listed in the
+/*If using another Arduino microcontroller, try commenting out line 66 and
+uncommenting line 75 due to the limitations listed in the
 library's note => https://www.arduino.cc/en/Reference/softwareSerial . Do
 not forget to rewire the connection to the Arduino.*/
 

--- a/src/FPS_GT511C3.cpp
+++ b/src/FPS_GT511C3.cpp
@@ -374,7 +374,8 @@ int FPS_GT511C3::GetEnrollCount()
 }
 
 // checks to see if the ID number is in use or not
-// Parameter: 0-199
+// Parameter: 0-2999, if using GT-521F52
+//            0-199, if using GT-521F32/GT-511C3
 // Return: True if the ID number is enrolled, false if not
 bool FPS_GT511C3::CheckEnrolled(int id)
 {
@@ -394,7 +395,8 @@ bool FPS_GT511C3::CheckEnrolled(int id)
 }
 
 // Starts the Enrollment Process
-// Parameter: 0-199
+// Parameter: 0-2999, if using GT-521F52
+//            0-199, if using GT-521F32/GT-511C3
 // Return:
 //	0 - ACK
 //	1 - Database is full
@@ -439,6 +441,8 @@ int FPS_GT511C3::Enroll1()
 	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	int retval = rp->IntFromParameter();
+//Change to  "retval < 3000", if using GT-521F52
+//Leave "reval < 200", if using GT-521F32/GT-511C3
 	if (retval < 200) retval = 3; else retval = 0;
 	if (rp->ACK == false)
 	{
@@ -466,6 +470,8 @@ int FPS_GT511C3::Enroll2()
 	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	int retval = rp->IntFromParameter();
+//Change to "retval < 3000", if using GT-521F52
+//Leave "reval < 200", if using GT-521F32/GT-511C3
 	if (retval < 200) retval = 3; else retval = 0;
 	if (rp->ACK == false)
 	{
@@ -494,7 +500,9 @@ int FPS_GT511C3::Enroll3()
 	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	int retval = rp->IntFromParameter();
-	if (retval < 200) retval = 3; else retval = 0;
+//Change to "retval < 3000", if using GT-521F52
+//Leave "reval < 200", if using GT-521F32/GT-511C3
+        if (retval < 200) retval = 3; else retval = 0;
 	if (rp->ACK == false)
 	{
 		if (rp->Error == Response_Packet::ErrorCodes::NACK_ENROLL_FAILED) retval = 1;
@@ -527,7 +535,8 @@ bool FPS_GT511C3::IsPressFinger()
 }
 
 // Deletes the specified ID (enrollment) from the database
-// Parameter: 0-199 (id number to be deleted)
+// Parameter: 0-2999, if using GT-521F52 (id number to be deleted)
+//            0-199, if using GT-521F32/GT-511C3(id number to be deleted)
 // Returns: true if successful, false if position invalid
 bool FPS_GT511C3::DeleteID(int id)
 {
@@ -563,7 +572,8 @@ bool FPS_GT511C3::DeleteAll()
 }
 
 // Checks the currently pressed finger against a specific ID
-// Parameter: 0-199 (id number to be checked)
+// Parameter: 0-2999, if using GT-521F52 (id number to be checked)
+//            0-199, if using GT-521F32/GT-511C3 (id number to be checked)
 // Returns:
 //	0 - Verified OK (the correct finger)
 //	1 - Invalid Position
@@ -594,8 +604,12 @@ int FPS_GT511C3::Verify1_1(int id)
 
 // Checks the currently pressed finger against all enrolled fingerprints
 // Returns:
-//	0-199: Verified against the specified ID (found, and here is the ID number)
-//	200: Failed to find the fingerprint in the database
+//	Verified against the specified ID (found, and here is the ID number)
+//           0-2999, if using GT-521F52
+//           0-199, if using GT-521F32/GT-511C3
+//      Failed to find the fingerprint in the database
+// 	     3000, if using GT-521F52
+//           200, if using GT-521F32/GT-511C3
 int FPS_GT511C3::Identify1_N()
 {
 	if (UseSerialDebug) Serial.println("FPS - Identify1_N");
@@ -606,6 +620,8 @@ int FPS_GT511C3::Identify1_N()
 	SendCommand(packetbytes, 12);
 	Response_Packet* rp = GetResponse();
 	int retval = rp->IntFromParameter();
+//Change to "retval > 3000" and "retval = 3000", if using GT-521F52
+//Leave "reval > 200" and "retval = 200", if using GT-521F32/GT-511C3
 	if (retval > 200) retval = 200;
 	delete rp;
 	delete packetbytes;

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -1,4 +1,4 @@
-/* 
+/*
 	FPS_GT511C3.h v1.0 - Library for controlling the GT-511C3 Finger Print Scanner (FPS)
 	Created by Josh Hawley, July 23rd 2013
 	Licensed for non-commercial use, must include this license message
@@ -214,12 +214,14 @@ class FPS_GT511C3
 	int GetEnrollCount();
 
 	// checks to see if the ID number is in use or not
-	// Parameter: 0-199
+	// Parameter: 0-2999, if using GT-521F52
+        //            0-199, if using GT-521F32/GT-511C3
 	// Return: True if the ID number is enrolled, false if not
 	bool CheckEnrolled(int id);
 
 	// Starts the Enrollment Process
-	// Parameter: 0-199
+	// Parameter: 0-2999, if using GT-521F52
+        //            0-199, if using GT-521F32/GT-511C3
 	// Return:
 	//	0 - ACK
 	//	1 - Database is full
@@ -265,7 +267,8 @@ class FPS_GT511C3
 	bool DeleteAll();
 
 	// Checks the currently pressed finger against a specific ID
-	// Parameter: 0-199 (id number to be checked)
+	// Parameter: 0-2999, if using GT-521F52 (id number to be checked)
+        //            0-199, if using GT-521F32/GT-511C3 (id number to be checked)
 	// Returns:
 	//	0 - Verified OK (the correct finger)
 	//	1 - Invalid Position
@@ -275,8 +278,12 @@ class FPS_GT511C3
 
 	// Checks the currently pressed finger against all enrolled fingerprints
 	// Returns:
-	//	0-199: Verified against the specified ID (found, and here is the ID number)
-	//	200: Failed to find the fingerprint in the database
+	//	Verified against the specified ID (found, and here is the ID number)
+        //           0-2999, if using GT-521F52
+        //           0-199, if using GT-521F32/GT-511C3
+        //      Failed to find the fingerprint in the database
+        // 	     3000, if using GT-521F52
+        //           200, if using GT-521F32/GT-511C3
 	int Identify1_N();
 
 	// Captures the currently pressed finger into onboard ram


### PR DESCRIPTION
- Add comments to reflect tests on GT-521F52 and GT-521F32
- Add comments to change parameter when using with GT-521F52 since it is able to hold 3000 IDs.