### PR TITLE
v1.2.1: Major rewrite and new features (data download)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,6 @@ Fingerprint Scanner-TTL
 
 This is a great fingerprint module from ADH-Tech that communicates over 3.3V TTL Serial so you can easily embed it into your next project. This repository contains Arduino example code to work with it. This code has been tested with GT-521F32, GT-521F52, GT-511C3, and GT-511C1R.
 
-Fork purpose
-====================================
-This fork implements a few of the remaining commands needed to extract the fingerprint DB contained in the original device, allowing to implement a server-based IoT service.
-
-Commands to implement:
-* bool GetImage()
-* bool GetRawImage()
-* int GetTemplate(int)
-* int SetTemplate(byte*, int, bool)
-
 Repository Contents
 -------------------
 * **/examples** - Example code to interface with the sensor.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ Fingerprint Scanner-TTL
 
 This is a great fingerprint module from ADH-Tech that communicates over 3.3V TTL Serial so you can easily embed it into your next project. This repository contains Arduino example code to work with it. This code has been tested with GT-521F32, GT-521F52, GT-511C3, and GT-511C1R.
 
+Fork purpose
+====================================
+This fork implements a few of the remaining commands needed to extract the fingerprint DB contained in the original device, allowing to implement a server-based IoT service.
+
+Commands to implement:
+* bool GetImage()
+* bool GetRawImage()
+* int GetTemplate(int)
+* int SetTemplate(byte*, int, bool)
+
 Repository Contents
 -------------------
 * **/examples** - Example code to interface with the sensor.

--- a/examples/FPS_Enroll/FPS_Enroll.ino
+++ b/examples/FPS_Enroll/FPS_Enroll.ino
@@ -101,20 +101,20 @@ void Enroll()
 	if (bret != false)
 	{
 		Serial.println("Remove finger");
-		fps.Enroll1(); 
+		iret = fps.Enroll1(); 
 		while(fps.IsPressFinger() == true) delay(100);
 		Serial.println("Press same finger again");
 		while(fps.IsPressFinger() == false) delay(100);
 		bret = fps.CaptureFinger(true);
-		if (bret != false)
+		if (bret != false && !iret)
 		{
 			Serial.println("Remove finger");
-			fps.Enroll2();
+			iret = fps.Enroll2();
 			while(fps.IsPressFinger() == true) delay(100);
 			Serial.println("Press same finger yet again");
 			while(fps.IsPressFinger() == false) delay(100);
 			bret = fps.CaptureFinger(true);
-			if (bret != false)
+			if (bret != false && !iret)
 			{
 				Serial.println("Remove finger");
 				iret = fps.Enroll3();
@@ -128,7 +128,17 @@ void Enroll()
 					Serial.println(iret);
 				}
 			}
+			else if (iret)
+			{
+				Serial.print("Enrolling Failed with error code:");
+				Serial.println(iret);
+			}
 			else Serial.println("Failed to capture third finger");
+		}
+		else if (iret)
+		{
+			Serial.print("Enrolling Failed with error code:");
+			Serial.println(iret);
 		}
 		else Serial.println("Failed to capture second finger");
 	}

--- a/library.json
+++ b/library.json
@@ -5,7 +5,7 @@
   "repository":
   {
     "type": "git",
-    "url": "https://github.com/Fasgort/Fingerprint_Scanner-TTL.git"
+    "url": "https://github.com/sparkfun/Fingerprint_Scanner-TTL.git"
   },
   "version": "1.2.2",
   "frameworks": "arduino",

--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/Fasgort/Fingerprint_Scanner-TTL.git"
   },
-  "version": "1.2.0",
+  "version": "1.2.2",
   "frameworks": "arduino",
   "platforms": "atmelavr"
 }

--- a/library.json
+++ b/library.json
@@ -5,7 +5,7 @@
   "repository":
   {
     "type": "git",
-    "url": "https://github.com/sparkfun/Fingerprint_Scanner-TTL.git"
+    "url": "https://github.com/Fasgort/Fingerprint_Scanner-TTL.git"
   },
   "version": "1.1.1",
   "frameworks": "arduino",

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=Fingerprint Scanner TTL
 version=1.2.2
 author=Josh Hawley, modified by David López Chica
-maintainer=David López Chica
+maintainer=SparkFun Electronics
 sentence=Arduino examples for ADH-Tech's Fingerprint Scanners.
 paragraph=This is a great fingerprint module from ADH-Tech that communicates over 3.3V TTL Serial so you can easily embed it into your next project. This repository contains Arduino example code to work with it. This code has been tested with GT-521F32, GT-521F52, GT-511C3, and GT-511C1R.
 category=Sensors
-url=https://github.com/Fasgort/Fingerprint_Scanner-TTL
+url=https://github.com/sparkfun/Fingerprint_Scanner-TTL
 architectures=*

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Fingerprint Scanner TTL
-version=1.2.0
+version=1.2.2
 author=Josh Hawley, modified by David López Chica
 maintainer=David López Chica
 sentence=Arduino examples for ADH-Tech's Fingerprint Scanners.

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=Fingerprint Scanner TTL
 version=1.1.0
-author=Josh Hawley
-maintainer=SparkFun Electronics
+author=Josh Hawley, modified by David López Chica
+maintainer=David López Chica
 sentence=Arduino examples for ADH-Tech's Fingerprint Scanners.
 paragraph=This is a great fingerprint module from ADH-Tech that communicates over 3.3V TTL Serial so you can easily embed it into your next project. This repository contains Arduino example code to work with it. This code has been tested with GT-521F32, GT-521F52, GT-511C3, and GT-511C1R.
 category=Sensors
-url=https://github.com/sparkfun/Fingerprint_Scanner-TTL
+url=https://github.com/Fasgort/Fingerprint_Scanner-TTL
 architectures=*

--- a/src/FPS_GT511C3.cpp
+++ b/src/FPS_GT511C3.cpp
@@ -14,16 +14,16 @@
 
 // returns the 12 bytes of the generated command packet
 // remember to call delete on the returned array
-byte* Command_Packet::GetPacketBytes()
+uint8_t* Command_Packet::GetPacketBytes()
 {
-	byte* packetbytes= new byte[12];
+	uint8_t* packetbytes= new uint8_t[12];
 
 	// update command before calculating checksum (important!)
-	word cmd = Command;
+	uint16_t cmd = Command;
 	command[0] = GetLowByte(cmd);
 	command[1] = GetHighByte(cmd);
 
-	word checksum = _CalculateChecksum();
+	uint16_t checksum = _CalculateChecksum();
 
 	packetbytes[0] = COMMAND_START_CODE_1;
 	packetbytes[1] = COMMAND_START_CODE_2;
@@ -41,30 +41,30 @@ byte* Command_Packet::GetPacketBytes()
 	return packetbytes;
 }
 
-// Converts the int to bytes and puts them into the paramter array
-void Command_Packet::ParameterFromInt(int i)
+// Converts the uint32_t to bytes and puts them into the parameter array
+void Command_Packet::ParameterFrom(uint32_t u)
 {
-	Parameter[0] = (i & 0x000000ff);
-	Parameter[1] = (i & 0x0000ff00) >> 8;
-	Parameter[2] = (i & 0x00ff0000) >> 16;
-	Parameter[3] = (i & 0xff000000) >> 24;
+	Parameter[0] = (u & 0x000000ff);
+	Parameter[1] = (u & 0x0000ff00) >> 8;
+	Parameter[2] = (u & 0x00ff0000) >> 16;
+	Parameter[3] = (u & 0xff000000) >> 24;
 }
 
 // Returns the high byte from a word
-byte Command_Packet::GetHighByte(word w)
+uint8_t Command_Packet::GetHighByte(uint16_t w)
 {
-	return (byte)(w>>8)&0x00FF;
+	return (uint8_t)(w>>8)&0x00FF;
 }
 
 // Returns the low byte from a word
-byte Command_Packet::GetLowByte(word w)
+uint8_t Command_Packet::GetLowByte(uint16_t w)
 {
-	return (byte)w&0x00FF;
+	return (uint8_t)w&0x00FF;
 }
 
-word Command_Packet::_CalculateChecksum()
+uint16_t Command_Packet::_CalculateChecksum()
 {
-	word w = 0;
+	uint16_t w = 0;
 	w += COMMAND_START_CODE_1;
 	w += COMMAND_START_CODE_2;
 	w += COMMAND_DEVICE_ID_1;
@@ -90,7 +90,7 @@ Command_Packet::Command_Packet()
 #pragma region -= Response_Packet Definitions =-
 #endif  //__GNUC__
 // creates and parses a response packet from the finger print scanner
-Response_Packet::Response_Packet(byte* buffer, bool UseSerialDebug)
+Response_Packet::Response_Packet(uint8_t* buffer, bool UseSerialDebug)
 {
 	CheckParsing(buffer[0], COMMAND_START_CODE_1, COMMAND_START_CODE_1, "COMMAND_START_CODE_1", UseSerialDebug);
 	CheckParsing(buffer[1], COMMAND_START_CODE_2, COMMAND_START_CODE_2, "COMMAND_START_CODE_2", UseSerialDebug);
@@ -100,9 +100,9 @@ Response_Packet::Response_Packet(byte* buffer, bool UseSerialDebug)
 	if (buffer[8] == 0x30) ACK = true; else ACK = false;
 	CheckParsing(buffer[9], 0x00, 0x00, "AckNak_HIGH", UseSerialDebug);
 
-	word checksum = CalculateChecksum(buffer, 10);
-	byte checksum_low = GetLowByte(checksum);
-	byte checksum_high = GetHighByte(checksum);
+	uint16_t checksum = CalculateChecksum(buffer, 10);
+	uint8_t checksum_low = GetLowByte(checksum);
+	uint8_t checksum_high = GetHighByte(checksum);
 	CheckParsing(buffer[10], checksum_low, checksum_low, "Checksum_LOW", UseSerialDebug);
 	CheckParsing(buffer[11], checksum_high, checksum_high, "Checksum_HIGH", UseSerialDebug);
 
@@ -121,7 +121,7 @@ Response_Packet::Response_Packet(byte* buffer, bool UseSerialDebug)
 }
 
 // parses bytes into one of the possible errors from the finger print scanner
-Response_Packet::ErrorCodes::Errors_Enum Response_Packet::ErrorCodes::ParseFromBytes(byte high, byte low)
+Response_Packet::ErrorCodes::Errors_Enum Response_Packet::ErrorCodes::ParseFromBytes(uint8_t high, uint8_t low)
 {
 	Errors_Enum e = INVALID;
 	if (high == 0x00)
@@ -157,10 +157,10 @@ Response_Packet::ErrorCodes::Errors_Enum Response_Packet::ErrorCodes::ParseFromB
 	return e;
 }
 
-// Gets an int from the parameter bytes
-int Response_Packet::IntFromParameter()
+// Gets a uint32_t from the parameter bytes
+uint32_t Response_Packet::FromParameter()
 {
-	int retval = 0;
+	uint32_t retval = 0;
 	retval = (retval << 8) + ParameterBytes[3];
 	retval = (retval << 8) + ParameterBytes[2];
 	retval = (retval << 8) + ParameterBytes[1];
@@ -169,7 +169,7 @@ int Response_Packet::IntFromParameter()
 }
 
 // checks to see if the byte is the proper value, and logs it to the serial channel if not
-bool Response_Packet::CheckParsing(byte b, byte propervalue, byte alternatevalue, const char* varname, bool UseSerialDebug)
+bool Response_Packet::CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname, bool UseSerialDebug)
 {
 	bool retval = (b != propervalue) && (b != alternatevalue);
 	if ((UseSerialDebug) && (retval))
@@ -187,10 +187,10 @@ bool Response_Packet::CheckParsing(byte b, byte propervalue, byte alternatevalue
 }
 
 // calculates the checksum from the bytes in the packet
-word Response_Packet::CalculateChecksum(byte* buffer, int length)
+uint16_t Response_Packet::CalculateChecksum(uint8_t* buffer, uint16_t length)
 {
-	word checksum = 0;
-	for (int i=0; i<length; i++)
+	uint16_t checksum = 0;
+	for (uint16_t i=0; i<length; i++)
 	{
 		checksum +=buffer[i];
 	}
@@ -198,15 +198,15 @@ word Response_Packet::CalculateChecksum(byte* buffer, int length)
 }
 
 // Returns the high byte from a word
-byte Response_Packet::GetHighByte(word w)
+uint8_t Response_Packet::GetHighByte(uint16_t w)
 {
-	return (byte)(w>>8)&0x00FF;
+	return (uint8_t)(w>>8)&0x00FF;
 }
 
 // Returns the low byte from a word
-byte Response_Packet::GetLowByte(word w)
+uint8_t Response_Packet::GetLowByte(uint16_t w)
 {
-	return (byte)w&0x00FF;
+	return (uint8_t)w&0x00FF;
 }
 #ifndef __GNUC__
 #pragma endregion
@@ -215,7 +215,7 @@ byte Response_Packet::GetLowByte(word w)
 #ifndef __GNUC__
 #pragma region -= Data_Packet =-
 #endif  //__GNUC__
-Data_Packet::Data_Packet(byte* buffer, bool UseSerialDebug)
+Data_Packet::Data_Packet(uint8_t* buffer, bool UseSerialDebug)
 {
     CheckParsing(buffer[0], DATA_START_CODE_1, DATA_START_CODE_1, "DATA_START_CODE_1", UseSerialDebug);
 	CheckParsing(buffer[1], DATA_START_CODE_2, DATA_START_CODE_2, "DATA_START_CODE_2", UseSerialDebug);
@@ -226,25 +226,25 @@ Data_Packet::Data_Packet(byte* buffer, bool UseSerialDebug)
 }
 
 // Get a data packet (128 bytes), calculate checksum and send it to serial
-void Data_Packet::GetData(byte* buffer, bool UseSerialDebug)
+void Data_Packet::GetData(uint8_t* buffer, bool UseSerialDebug)
 {
     SendToSerial(buffer, 128);
     this->checksum = CalculateChecksum(buffer, 128);
 }
 
 // Get the last data packet (<=128 bytes), calculate checksum, validate checksum received and send it to serial
-void Data_Packet::GetLastData(byte* buffer, int length, bool UseSerialDebug)
+void Data_Packet::GetLastData(uint8_t* buffer, uint16_t length, bool UseSerialDebug)
 {
     SendToSerial(buffer, length-2);
     this->checksum = CalculateChecksum(buffer, length);
-	byte checksum_low = GetLowByte(this->checksum);
-	byte checksum_high = GetHighByte(this->checksum);
+	uint8_t checksum_low = GetLowByte(this->checksum);
+	uint8_t checksum_high = GetHighByte(this->checksum);
 	CheckParsing(buffer[length-2], checksum_low, checksum_low, "Checksum_LOW", UseSerialDebug);
 	CheckParsing(buffer[length-1], checksum_high, checksum_high, "Checksum_HIGH", UseSerialDebug);
 }
 
 // checks to see if the byte is the proper value, and logs it to the serial channel if not
-bool Data_Packet::CheckParsing(byte b, byte propervalue, byte alternatevalue, const char* varname, bool UseSerialDebug)
+bool Data_Packet::CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname, bool UseSerialDebug)
 {
 	bool retval = (b != propervalue) && (b != alternatevalue);
 	if ((UseSerialDebug) && (retval))
@@ -262,10 +262,10 @@ bool Data_Packet::CheckParsing(byte b, byte propervalue, byte alternatevalue, co
 }
 
 // calculates the checksum from the bytes in the packet
-word Data_Packet::CalculateChecksum(byte* buffer, int length)
+uint16_t Data_Packet::CalculateChecksum(uint8_t* buffer, uint16_t length)
 {
-	word checksum = this->checksum;
-	for (int i=0; i<length; i++)
+	uint16_t checksum = this->checksum;
+	for (uint16_t i=0; i<length; i++)
 	{
 		checksum +=buffer[i];
 	}
@@ -273,31 +273,31 @@ word Data_Packet::CalculateChecksum(byte* buffer, int length)
 }
 
 // Returns the high byte from a word
-byte Data_Packet::GetHighByte(word w)
+uint8_t Data_Packet::GetHighByte(uint16_t w)
 {
-	return (byte)(w>>8)&0x00FF;
+	return (uint8_t)(w>>8)&0x00FF;
 }
 
 // Returns the low byte from a word
-byte Data_Packet::GetLowByte(word w)
+uint8_t Data_Packet::GetLowByte(uint16_t w)
 {
-	return (byte)w&0x00FF;
+	return (uint8_t)w&0x00FF;
 }
 
 // sends a byte to the serial debugger in the hex format we want EX "0F"
-void Data_Packet::serialPrintHex(byte data)
+void Data_Packet::serialPrintHex(uint8_t data)
 {
   char tmp[16];
   sprintf(tmp, "%.2X",data);
   Serial.print(tmp);
 }
 
-// sends the bye aray to the serial debugger in our hex format EX: "00 AF FF 10 00 13"
-void Data_Packet::SendToSerial(byte data[], int length)
+// sends the byte array to the serial debugger in our hex format EX: "00 AF FF 10 00 13"
+void Data_Packet::SendToSerial(uint8_t data[], uint16_t length)
 {
   boolean first=true;
   Serial.print("\"");
-  for(int i=0; i<length; i++)
+  for(uint16_t i=0; i<length; i++)
   {
 	if (first) first=false; else Serial.print(" ");
 	serialPrintHex(data[i]);
@@ -316,12 +316,12 @@ void Data_Packet::SendToSerial(byte data[], int length)
 #pragma region -= Constructor/Destructor =-
 #endif  //__GNUC__
 // Creates a new object to interface with the fingerprint scanner
-FPS_GT511C3::FPS_GT511C3(uint8_t rx, uint8_t tx)
+FPS_GT511C3::FPS_GT511C3(uint8_t rx, uint8_t tx, uint32_t baud)
 	: _serial(rx,tx)
 {
 	pin_RX = rx;
 	pin_TX = tx;
-	_serial.begin(9600);
+	_serial.begin(baud);
 	this->UseSerialDebug = false;
 };
 
@@ -347,7 +347,7 @@ void FPS_GT511C3::Open()
 	cp->Parameter[1] = 0x00;
 	cp->Parameter[2] = 0x00;
 	cp->Parameter[3] = 0x00;
-	byte* packetbytes = cp->GetPacketBytes();
+	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
 	Response_Packet* rp = GetResponse();
@@ -366,7 +366,7 @@ void FPS_GT511C3::Close()
 	cp->Parameter[1] = 0x00;
 	cp->Parameter[2] = 0x00;
 	cp->Parameter[3] = 0x00;
-	byte* packetbytes = cp->GetPacketBytes();
+	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
 	Response_Packet* rp = GetResponse();
@@ -394,7 +394,7 @@ bool FPS_GT511C3::SetLED(bool on)
 	cp->Parameter[1] = 0x00;
 	cp->Parameter[2] = 0x00;
 	cp->Parameter[3] = 0x00;
-	byte* packetbytes = cp->GetPacketBytes();
+	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
 	Response_Packet* rp = GetResponse();
@@ -409,25 +409,21 @@ bool FPS_GT511C3::SetLED(bool on)
 // Parameter: 9600, 19200, 38400, 57600, 115200
 // Returns: True if success, false if invalid baud
 // NOTE: Untested (don't have a logic level changer and a voltage divider is too slow)
-bool FPS_GT511C3::ChangeBaudRate(unsigned long baud)
+bool FPS_GT511C3::ChangeBaudRate(uint32_t baud)
 {
-	if ((baud == 9600) || (baud == 19200) || (baud == 38400) || (baud == 57600) || (baud == 115200))
+    if ((baud == 9600) || (baud == 19200) || (baud == 38400) || (baud == 57600) || (baud == 115200))
 	{
 
 		if (UseSerialDebug) Serial.println("FPS - ChangeBaudRate");
 		Command_Packet* cp = new Command_Packet();
 		cp->Command = Command_Packet::Commands::ChangeBaudRate;
-		cp->ParameterFromInt(baud);
-		byte* packetbytes = cp->GetPacketBytes();
+		cp->ParameterFrom(baud);
+		uint8_t* packetbytes = cp->GetPacketBytes();
 		delete cp;
 		SendCommand(packetbytes, 12);
 		Response_Packet* rp = GetResponse();
 		bool retval = rp->ACK;
-		if (retval)
-		{
-			_serial.end();
-			_serial.begin(baud);
-		}
+		if (retval) _serial.begin(baud);
 		delete rp;
 		delete packetbytes;
 		return retval;
@@ -437,7 +433,7 @@ bool FPS_GT511C3::ChangeBaudRate(unsigned long baud)
 
 // Gets the number of enrolled fingerprints
 // Return: The total number of enrolled fingerprints
-int FPS_GT511C3::GetEnrollCount()
+uint16_t FPS_GT511C3::GetEnrollCount()
 {
 	if (UseSerialDebug) Serial.println("FPS - GetEnrolledCount");
 	Command_Packet* cp = new Command_Packet();
@@ -446,12 +442,12 @@ int FPS_GT511C3::GetEnrollCount()
 	cp->Parameter[1] = 0x00;
 	cp->Parameter[2] = 0x00;
 	cp->Parameter[3] = 0x00;
-	byte* packetbytes = cp->GetPacketBytes();
+	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
 	Response_Packet* rp = GetResponse();
 
-	int retval = rp->IntFromParameter();
+	uint32_t retval = rp->FromParameter();
 	delete rp;
 	delete packetbytes;
 	return retval;
@@ -461,13 +457,13 @@ int FPS_GT511C3::GetEnrollCount()
 // Parameter: 0-2999, if using GT-521F52
 //            0-199, if using GT-521F32/GT-511C3
 // Return: True if the ID number is enrolled, false if not
-bool FPS_GT511C3::CheckEnrolled(int id)
+bool FPS_GT511C3::CheckEnrolled(uint16_t id)
 {
 	if (UseSerialDebug) Serial.println("FPS - CheckEnrolled");
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::CheckEnrolled;
-	cp->ParameterFromInt(id);
-	byte* packetbytes = cp->GetPacketBytes();
+	cp->ParameterFrom(id);
+	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
 	delete packetbytes;
@@ -486,18 +482,18 @@ bool FPS_GT511C3::CheckEnrolled(int id)
 //	1 - Database is full
 //	2 - Invalid Position
 //	3 - Position(ID) is already used
-int FPS_GT511C3::EnrollStart(int id)
+uint8_t FPS_GT511C3::EnrollStart(uint16_t id)
 {
 	if (UseSerialDebug) Serial.println("FPS - EnrollStart");
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::EnrollStart;
-	cp->ParameterFromInt(id);
-	byte* packetbytes = cp->GetPacketBytes();
+	cp->ParameterFrom(id);
+	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
 	delete packetbytes;
 	Response_Packet* rp = GetResponse();
-	int retval = 0;
+	uint8_t retval = 0;
 	if (rp->ACK == false)
 	{
 		if (rp->Error == Response_Packet::ErrorCodes::NACK_DB_IS_FULL) retval = 1;
@@ -514,17 +510,17 @@ int FPS_GT511C3::EnrollStart(int id)
 //	1 - Enroll Failed
 //	2 - Bad finger
 //	3 - ID in use
-int FPS_GT511C3::Enroll1()
+uint8_t FPS_GT511C3::Enroll1()
 {
 	if (UseSerialDebug) Serial.println("FPS - Enroll1");
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Enroll1;
-	byte* packetbytes = cp->GetPacketBytes();
+	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
 	delete packetbytes;
 	Response_Packet* rp = GetResponse();
-	int retval = rp->IntFromParameter();
+	uint32_t retval = rp->FromParameter();
 //Change to  "retval < 3000", if using GT-521F52
 //Leave "reval < 200", if using GT-521F32/GT-511C3
 	if (retval < 200) retval = 3; else retval = 0;
@@ -543,7 +539,7 @@ int FPS_GT511C3::Enroll1()
 //	1 - Enroll Failed
 //	2 - Bad finger
 //	3 - ID in use
-int FPS_GT511C3::Enroll2()
+uint8_t FPS_GT511C3::Enroll2()
 {
 	if (UseSerialDebug) Serial.println("FPS - Enroll2");
 	Command_Packet* cp = new Command_Packet();
@@ -553,7 +549,7 @@ int FPS_GT511C3::Enroll2()
 	SendCommand(packetbytes, 12);
 	delete packetbytes;
 	Response_Packet* rp = GetResponse();
-	int retval = rp->IntFromParameter();
+	uint32_t retval = rp->FromParameter();
 //Change to "retval < 3000", if using GT-521F52
 //Leave "reval < 200", if using GT-521F32/GT-511C3
 	if (retval < 200) retval = 3; else retval = 0;
@@ -573,7 +569,7 @@ int FPS_GT511C3::Enroll2()
 //	1 - Enroll Failed
 //	2 - Bad finger
 //	3 - ID in use
-int FPS_GT511C3::Enroll3()
+uint8_t FPS_GT511C3::Enroll3()
 {
 	if (UseSerialDebug) Serial.println("FPS - Enroll3");
 	Command_Packet* cp = new Command_Packet();
@@ -583,7 +579,7 @@ int FPS_GT511C3::Enroll3()
 	SendCommand(packetbytes, 12);
 	delete packetbytes;
 	Response_Packet* rp = GetResponse();
-	int retval = rp->IntFromParameter();
+	uint32_t retval = rp->FromParameter();
 //Change to "retval < 3000", if using GT-521F52
 //Leave "reval < 200", if using GT-521F32/GT-511C3
         if (retval < 200) retval = 3; else retval = 0;
@@ -603,16 +599,17 @@ bool FPS_GT511C3::IsPressFinger()
 	if (UseSerialDebug) Serial.println("FPS - IsPressFinger");
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::IsPressFinger;
-	byte* packetbytes = cp->GetPacketBytes();
+	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
 	Response_Packet* rp = GetResponse();
 	bool retval = false;
-	int pval = rp->ParameterBytes[0];
+/*  int pval = rp->ParameterBytes[0];
 	pval += rp->ParameterBytes[1];
 	pval += rp->ParameterBytes[2];
 	pval += rp->ParameterBytes[3];
-	if (pval == 0) retval = true;
+	if (pval == 0) retval = true;   */
+    if (!rp->ParameterBytes[0] && !rp->ParameterBytes[1] && !rp->ParameterBytes[2] && !rp->ParameterBytes[3]) retval = true;
 	delete rp;
 	delete packetbytes;
 	return retval;
@@ -622,13 +619,13 @@ bool FPS_GT511C3::IsPressFinger()
 // Parameter: 0-2999, if using GT-521F52 (id number to be deleted)
 //            0-199, if using GT-521F32/GT-511C3(id number to be deleted)
 // Returns: true if successful, false if position invalid
-bool FPS_GT511C3::DeleteID(int id)
+bool FPS_GT511C3::DeleteID(uint16_t id)
 {
 	if (UseSerialDebug) Serial.println("FPS - DeleteID");
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::DeleteID;
-	cp->ParameterFromInt(id);
-	byte* packetbytes = cp->GetPacketBytes();
+	cp->ParameterFrom(id);
+	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
 	Response_Packet* rp = GetResponse();
@@ -645,7 +642,7 @@ bool FPS_GT511C3::DeleteAll()
 	if (UseSerialDebug) Serial.println("FPS - DeleteAll");
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::DeleteAll;
-	byte* packetbytes = cp->GetPacketBytes();
+	uint8_t* packetbytes = cp->GetPacketBytes();
 	SendCommand(packetbytes, 12);
 	Response_Packet* rp = GetResponse();
 	bool retval = rp->ACK;
@@ -663,17 +660,17 @@ bool FPS_GT511C3::DeleteAll()
 //	1 - Invalid Position
 //	2 - ID is not in use
 //	3 - Verified FALSE (not the correct finger)
-int FPS_GT511C3::Verify1_1(int id)
+uint8_t FPS_GT511C3::Verify1_1(uint16_t id)
 {
 	if (UseSerialDebug) Serial.println("FPS - Verify1_1");
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Verify1_1;
-	cp->ParameterFromInt(id);
-	byte* packetbytes = cp->GetPacketBytes();
+	cp->ParameterFrom(id);
+	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
 	Response_Packet* rp = GetResponse();
-	int retval = 0;
+	uint8_t retval = 0;
 	if (rp->ACK == false)
 	{
 		retval = 3; // grw 01/03/15 - set default value of not verified before assignment
@@ -694,16 +691,16 @@ int FPS_GT511C3::Verify1_1(int id)
 //      Failed to find the fingerprint in the database
 // 	     3000, if using GT-521F52
 //           200, if using GT-521F32/GT-511C3
-int FPS_GT511C3::Identify1_N()
+uint16_t FPS_GT511C3::Identify1_N()
 {
 	if (UseSerialDebug) Serial.println("FPS - Identify1_N");
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Identify1_N;
-	byte* packetbytes = cp->GetPacketBytes();
+	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
 	Response_Packet* rp = GetResponse();
-	int retval = rp->IntFromParameter();
+	uint32_t retval = rp->FromParameter();
 //Change to "retval > 3000" and "retval = 3000", if using GT-521F52
 //Leave "reval > 200" and "retval = 200", if using GT-521F32/GT-511C3
 	if (retval > 200) retval = 200;
@@ -723,13 +720,13 @@ bool FPS_GT511C3::CaptureFinger(bool highquality)
 	cp->Command = Command_Packet::Commands::CaptureFinger;
 	if (highquality)
 	{
-		cp->ParameterFromInt(1);
+		cp->ParameterFrom(1);
 	}
 	else
 	{
-		cp->ParameterFromInt(0);
+		cp->ParameterFrom(0);
 	}
-	byte* packetbytes = cp->GetPacketBytes();
+	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
 	Response_Packet* rp = GetResponse();
@@ -747,7 +744,7 @@ bool FPS_GT511C3::GetImage()
     if (UseSerialDebug) Serial.println("FPS - GetImage");
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::GetRawImage;
-	byte* packetbytes = cp->GetPacketBytes();
+	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
 	Response_Packet* rp = GetResponse();
@@ -766,7 +763,7 @@ bool FPS_GT511C3::GetRawImage()
     if (UseSerialDebug) Serial.println("FPS - GetRawImage");
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::GetRawImage;
-	byte* packetbytes = cp->GetPacketBytes();
+	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
 	Response_Packet* rp = GetResponse();
@@ -851,7 +848,7 @@ bool FPS_GT511C3::GetRawImage()
 #pragma region -= Private Methods =-
 #endif  //__GNUC__
 // Sends the command to the software serial channel
-void FPS_GT511C3::SendCommand(byte cmd[], int length)
+void FPS_GT511C3::SendCommand(uint8_t cmd[], uint16_t length)
 {
 	_serial.write(cmd, length);
 	if (UseSerialDebug)
@@ -865,23 +862,23 @@ void FPS_GT511C3::SendCommand(byte cmd[], int length)
 // Gets the response to the command from the software serial channel (and waits for it)
 Response_Packet* FPS_GT511C3::GetResponse()
 {
-	byte firstbyte = 0;
+	uint8_t firstbyte = 0;
 	bool done = false;
 	_serial.listen();
 	while (done == false)
 	{
-		firstbyte = (byte)_serial.read();
+		firstbyte = (uint8_t)_serial.read();
 		if (firstbyte == Response_Packet::COMMAND_START_CODE_1)
 		{
 			done = true;
 		}
 	}
-	byte* resp = new byte[12];
+	uint8_t* resp = new uint8_t[12];
 	resp[0] = firstbyte;
-	for (int i=1; i < 12; i++)
+	for (uint8_t i=1; i < 12; i++)
 	{
 		while (_serial.available() == false) delay(10);
-		resp[i]= (byte) _serial.read();
+		resp[i]= (uint8_t) _serial.read();
 	}
 	Response_Packet* rp = new Response_Packet(resp, UseSerialDebug);
 	delete resp;
@@ -897,18 +894,18 @@ Response_Packet* FPS_GT511C3::GetResponse()
 
 // Gets the data (length bytes) from the software serial channel (and waits for it)
 // and sends it over serial sommunications
-void FPS_GT511C3::GetData(int length)
+void FPS_GT511C3::GetData(uint16_t length)
 {
-	byte firstbyte = 0;
-	byte secondbyte = 0;
+	uint8_t firstbyte = 0;
+	uint8_t secondbyte = 0;
 	bool done = false;
 	_serial.listen();
 	while (done == false)
 	{
-		firstbyte = (byte)_serial.read();
+		firstbyte = (uint8_t)_serial.read();
 		if (firstbyte == Data_Packet::DATA_START_CODE_1)
 		{
-		    secondbyte = (byte)_serial.read();
+		    secondbyte = (uint8_t)_serial.read();
 		    if (secondbyte == Data_Packet::DATA_START_CODE_2)
             {
                 done = true;
@@ -916,13 +913,13 @@ void FPS_GT511C3::GetData(int length)
 		}
 	}
 
-    byte* firstdata = new byte[4];
+    uint8_t* firstdata = new uint8_t[4];
 	firstdata[0] = firstbyte;
 	firstdata[1] = secondbyte;
-	for (int i=2; i < 4; i++)
+	for (uint8_t i=2; i < 4; i++)
 	{
 		while (_serial.available() == false) delay(10);
-		firstdata[i]= (byte) _serial.read();
+		firstdata[i]= (uint8_t) _serial.read();
 	}
 	Data_Packet* dp = new Data_Packet(firstdata, UseSerialDebug);
 	if(UseSerialDebug)
@@ -934,22 +931,22 @@ void FPS_GT511C3::GetData(int length)
     }
     delete firstdata;
 
-	int numberPacketsNeeded = (length-4) / 128;
+	uint16_t numberPacketsNeeded = (length-4) / 128;
 	bool smallLastPacket = false;
-	int lastPacketSize = (length-4) % 128;
+	uint8_t lastPacketSize = (length-4) % 128;
 	if(lastPacketSize != 0)
 	{
             numberPacketsNeeded++;
             smallLastPacket = true;
 	}
 
-	for (int packetCount=1; packetCount < numberPacketsNeeded; packetCount++)
+    uint8_t* data = new uint8_t[128];
+	for (uint16_t packetCount=1; packetCount < numberPacketsNeeded; packetCount++)
     {
-        byte* data = new byte[128];
-        for (int i=0; i < 128; i++)
+        for (uint8_t i=0; i < 128; i++)
         {
             while (_serial.available() == false) delay(10);
-            data[i]= (byte) _serial.read();
+            data[i]= (uint8_t) _serial.read();
         }
         dp->GetData(data, UseSerialDebug);
         if(UseSerialDebug)
@@ -959,14 +956,14 @@ void FPS_GT511C3::GetData(int length)
             Serial.println();
             Serial.println();
         }
-        delete data;
 	}
+	delete data;
 
-	byte* lastdata = new byte[lastPacketSize];
-	for (int i=0; i < lastPacketSize; i++)
+	uint8_t* lastdata = new uint8_t[lastPacketSize];
+	for (uint8_t i=0; i < lastPacketSize; i++)
 	{
 		while (_serial.available() == false) delay(10);
-		lastdata[i]= (byte) _serial.read();
+		lastdata[i]= (uint8_t) _serial.read();
 	}
 	dp->GetLastData(lastdata, lastPacketSize, UseSerialDebug);
 	if(UseSerialDebug)
@@ -981,12 +978,12 @@ void FPS_GT511C3::GetData(int length)
 	return;
 };
 
-// sends the bye aray to the serial debugger in our hex format EX: "00 AF FF 10 00 13"
-void FPS_GT511C3::SendToSerial(byte data[], int length)
+// sends the byte array to the serial debugger in our hex format EX: "00 AF FF 10 00 13"
+void FPS_GT511C3::SendToSerial(uint8_t data[], uint16_t length)
 {
   boolean first=true;
   Serial.print("\"");
-  for(int i=0; i<length; i++)
+  for(uint16_t i=0; i<length; i++)
   {
 	if (first) first=false; else Serial.print(" ");
 	serialPrintHex(data[i]);
@@ -995,7 +992,7 @@ void FPS_GT511C3::SendToSerial(byte data[], int length)
 }
 
 // sends a byte to the serial debugger in the hex format we want EX "0F"
-void FPS_GT511C3::serialPrintHex(byte data)
+void FPS_GT511C3::serialPrintHex(uint8_t data)
 {
   char tmp[16];
   sprintf(tmp, "%.2X",data);

--- a/src/FPS_GT511C3.cpp
+++ b/src/FPS_GT511C3.cpp
@@ -730,12 +730,28 @@ bool FPS_GT511C3::CaptureFinger(bool highquality)
 
 }
 
-// Gets an image that is qvga 160x120 (19200 bytes) and returns it in 150 Data_Packets
-// Use StartDataDownload, and then GetNextDataPacket until done
-// Returns: True (device confirming download starting)
-	// Not implemented due to memory restrictions on the arduino
-	// may revisit this if I find a need for it
-/*bool FPS_GT511C3::GetRawImage()
+// Gets an image that is 258x202 (52116 bytes) and sends it over serial
+// Returns: True (device confirming download)
+bool FPS_GT511C3::GetImage()
+{
+    if (UseSerialDebug) Serial.println("FPS - GetImage");
+	Command_Packet* cp = new Command_Packet();
+	cp->Command = Command_Packet::Commands::GetRawImage;
+	byte* packetbytes = cp->GetPacketBytes();
+	delete cp;
+	SendCommand(packetbytes, 12);
+	Response_Packet* rp = GetResponse();
+	bool retval = rp->ACK;
+	delete rp;
+	delete packetbytes;
+	GetData(52116);
+	return retval;
+
+}
+
+// Gets an image that is qvga 160x120 (19200 bytes) and sends it over serial
+// Returns: True (device confirming download)
+bool FPS_GT511C3::GetRawImage()
 {
     if (UseSerialDebug) Serial.println("FPS - GetRawImage");
 	Command_Packet* cp = new Command_Packet();
@@ -747,10 +763,10 @@ bool FPS_GT511C3::CaptureFinger(bool highquality)
 	bool retval = rp->ACK;
 	delete rp;
 	delete packetbytes;
+	GetData(19200);
 	return retval;
 
-	//return false;
-}*/
+}
 #ifndef __GNUC__
 #pragma endregion
 #endif  //__GNUC__

--- a/src/FPS_GT511C3.cpp
+++ b/src/FPS_GT511C3.cpp
@@ -416,7 +416,7 @@ bool FPS_GT511C3::ChangeBaudRate(unsigned long baud)
 
 		if (UseSerialDebug) Serial.println("FPS - ChangeBaudRate");
 		Command_Packet* cp = new Command_Packet();
-		cp->Command = Command_Packet::Commands::Open;
+		cp->Command = Command_Packet::Commands::ChangeBaudRate;
 		cp->ParameterFromInt(baud);
 		byte* packetbytes = cp->GetPacketBytes();
 		delete cp;

--- a/src/FPS_GT511C3.cpp
+++ b/src/FPS_GT511C3.cpp
@@ -92,10 +92,10 @@ Command_Packet::Command_Packet()
 // creates and parses a response packet from the finger print scanner
 Response_Packet::Response_Packet(uint8_t* buffer, bool UseSerialDebug)
 {
-	CheckParsing(buffer[0], COMMAND_START_CODE_1, COMMAND_START_CODE_1, "COMMAND_START_CODE_1", UseSerialDebug);
-	CheckParsing(buffer[1], COMMAND_START_CODE_2, COMMAND_START_CODE_2, "COMMAND_START_CODE_2", UseSerialDebug);
-	CheckParsing(buffer[2], COMMAND_DEVICE_ID_1, COMMAND_DEVICE_ID_1, "COMMAND_DEVICE_ID_1", UseSerialDebug);
-	CheckParsing(buffer[3], COMMAND_DEVICE_ID_2, COMMAND_DEVICE_ID_2, "COMMAND_DEVICE_ID_2", UseSerialDebug);
+	CheckParsing(buffer[0], RESPONSE_START_CODE_1, RESPONSE_START_CODE_1, "RESPONSE_START_CODE_1", UseSerialDebug);
+	CheckParsing(buffer[1], RESPONSE_START_CODE_2, RESPONSE_START_CODE_2, "RESPONSE_START_CODE_2", UseSerialDebug);
+	CheckParsing(buffer[2], RESPONSE_DEVICE_ID_1, RESPONSE_DEVICE_ID_1, "RESPONSE_DEVICE_ID_1", UseSerialDebug);
+	CheckParsing(buffer[3], RESPONSE_DEVICE_ID_2, RESPONSE_DEVICE_ID_2, "RESPONSE_DEVICE_ID_2", UseSerialDebug);
 	CheckParsing(buffer[8], 0x30, 0x31, "AckNak_LOW", UseSerialDebug);
 	if (buffer[8] == 0x30) ACK = true; else ACK = false;
 	CheckParsing(buffer[9], 0x00, 0x00, "AckNak_HIGH", UseSerialDebug);
@@ -336,11 +336,11 @@ bool FPS_GT511C3::Open()
 	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
+	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	bool retval = true;
 	if (rp->ACK == false) retval = false;
 	delete rp;
-	delete packetbytes;
 	return retval;
 }
 
@@ -358,9 +358,9 @@ void FPS_GT511C3::Close()
 	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
+	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	delete rp;
-	delete packetbytes;
 };
 
 // Turns on or off the LED backlight
@@ -386,11 +386,11 @@ bool FPS_GT511C3::SetLED(bool on)
 	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
+	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	bool retval = true;
 	if (rp->ACK == false) retval = false;
 	delete rp;
-	delete packetbytes;
 	return retval;
 };
 
@@ -409,11 +409,11 @@ bool FPS_GT511C3::ChangeBaudRate(uint32_t baud)
 		uint8_t* packetbytes = cp->GetPacketBytes();
 		delete cp;
 		SendCommand(packetbytes, 12);
+		delete packetbytes;
 		Response_Packet* rp = GetResponse();
 		bool retval = rp->ACK;
 		if (retval) _serial.begin(baud);
 		delete rp;
-		delete packetbytes;
 		return retval;
 	}
 	return false;
@@ -433,11 +433,10 @@ uint16_t FPS_GT511C3::GetEnrollCount()
 	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
+	delete packetbytes;
 	Response_Packet* rp = GetResponse();
-
 	uint32_t retval = rp->FromParameter();
 	delete rp;
-	delete packetbytes;
 	return retval;
 }
 
@@ -509,8 +508,8 @@ uint8_t FPS_GT511C3::Enroll1()
 	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	uint32_t retval = rp->FromParameter();
-//Change to  "retval < 3000", if using GT-521F52
-//Leave "reval < 200", if using GT-521F32/GT-511C3
+    //Change to  "retval < 3000", if using GT-521F52
+    //Leave "reval < 200", if using GT-521F32/GT-511C3
 	if (retval < 200) retval = 3; else retval = 0;
 	if (rp->ACK == false)
 	{
@@ -538,8 +537,8 @@ uint8_t FPS_GT511C3::Enroll2()
 	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	uint32_t retval = rp->FromParameter();
-//Change to "retval < 3000", if using GT-521F52
-//Leave "reval < 200", if using GT-521F32/GT-511C3
+    //Change to "retval < 3000", if using GT-521F52
+    //Leave "reval < 200", if using GT-521F32/GT-511C3
 	if (retval < 200) retval = 3; else retval = 0;
 	if (rp->ACK == false)
 	{
@@ -568,9 +567,9 @@ uint8_t FPS_GT511C3::Enroll3()
 	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	uint32_t retval = rp->FromParameter();
-//Change to "retval < 3000", if using GT-521F52
-//Leave "reval < 200", if using GT-521F32/GT-511C3
-        if (retval < 200) retval = 3; else retval = 0;
+    //Change to "retval < 3000", if using GT-521F52
+    //Leave "reval < 200", if using GT-521F32/GT-511C3
+    if (retval < 200) retval = 3; else retval = 0;
 	if (rp->ACK == false)
 	{
 		if (rp->Error == Response_Packet::ErrorCodes::NACK_ENROLL_FAILED) retval = 1;
@@ -590,16 +589,11 @@ bool FPS_GT511C3::IsPressFinger()
 	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
+	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	bool retval = false;
-/*  int pval = rp->ParameterBytes[0];
-	pval += rp->ParameterBytes[1];
-	pval += rp->ParameterBytes[2];
-	pval += rp->ParameterBytes[3];
-	if (pval == 0) retval = true;   */
     if (!rp->ParameterBytes[0] && !rp->ParameterBytes[1] && !rp->ParameterBytes[2] && !rp->ParameterBytes[3]) retval = true;
 	delete rp;
-	delete packetbytes;
 	return retval;
 }
 
@@ -616,10 +610,10 @@ bool FPS_GT511C3::DeleteID(uint16_t id)
 	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
+	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	bool retval = rp->ACK;
 	delete rp;
-	delete packetbytes;
 	return retval;
 }
 
@@ -632,10 +626,10 @@ bool FPS_GT511C3::DeleteAll()
 	cp->Command = Command_Packet::Commands::DeleteAll;
 	uint8_t* packetbytes = cp->GetPacketBytes();
 	SendCommand(packetbytes, 12);
+	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	bool retval = rp->ACK;
 	delete rp;
-	delete packetbytes;
 	delete cp;
 	return retval;
 }
@@ -657,6 +651,7 @@ uint8_t FPS_GT511C3::Verify1_1(uint16_t id)
 	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
+	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	uint8_t retval = 0;
 	if (rp->ACK == false)
@@ -667,7 +662,6 @@ uint8_t FPS_GT511C3::Verify1_1(uint16_t id)
 		if (rp->Error == Response_Packet::ErrorCodes::NACK_VERIFY_FAILED) retval = 3;
 	}
 	delete rp;
-	delete packetbytes;
 	return retval;
 }
 
@@ -687,13 +681,13 @@ uint16_t FPS_GT511C3::Identify1_N()
 	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
+	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	uint32_t retval = rp->FromParameter();
 //Change to "retval > 3000" and "retval = 3000", if using GT-521F52
 //Leave "reval > 200" and "retval = 200", if using GT-521F32/GT-511C3
 	if (retval > 200) retval = 200;
 	delete rp;
-	delete packetbytes;
 	return retval;
 }
 
@@ -717,12 +711,11 @@ bool FPS_GT511C3::CaptureFinger(bool highquality)
 	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
+	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	bool retval = rp->ACK;
 	delete rp;
-	delete packetbytes;
 	return retval;
-
 }
 
 // Gets an image that is 258x202 (52116 bytes) and sends it over serial
@@ -739,13 +732,12 @@ bool FPS_GT511C3::GetImage()
 	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
+    delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	bool retval = rp->ACK;
 	delete rp;
-	delete packetbytes;
 	GetData(52116+6);
 	return retval;
-
 }
 
 // Gets an image that is qvga 160x120 (19200 bytes) and sends it over serial
@@ -762,13 +754,94 @@ bool FPS_GT511C3::GetRawImage()
 	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);
+	delete packetbytes;
 	Response_Packet* rp = GetResponse();
 	bool retval = rp->ACK;
 	delete rp;
-	delete packetbytes;
 	GetData(19200+6);
 	return retval;
+}
 
+// Gets a template from the fps (498 bytes)
+// Parameter: 0-199 ID number
+// Returns:
+//	0 - ACK Download starting
+//	1 - Invalid position
+//	2 - ID not used (no template to download
+uint8_t FPS_GT511C3::GetTemplate(uint16_t id)
+{
+    if (UseSerialDebug) Serial.println("FPS - GetTemplate");
+	Command_Packet* cp = new Command_Packet();
+	cp->Command = Command_Packet::Commands::GetTemplate;
+	cp->ParameterFrom(id);
+	uint8_t* packetbytes = cp->GetPacketBytes();
+	delete cp;
+	SendCommand(packetbytes, 12);
+    delete packetbytes;
+	Response_Packet* rp = GetResponse();
+	if(rp->ACK)
+	{
+        delete rp;
+        GetData(498+6);
+        return 0;
+	} else
+	{
+	    uint32_t retval = rp->FromParameter();
+	    delete rp;
+	    return retval;
+	}
+}
+
+// Uploads a template to the fps
+// Parameter: the template (498 bytes)
+// Parameter: the ID number to upload
+// Parameter: Check for duplicate fingerprints already on fps
+// Returns:
+// -1 - Undefined error (shouldn't ever happen)
+//	0 - Uploaded ok (no duplicate if enabled)
+//	1 - ID duplicated
+//	2 - Invalid position
+//	3 - Communications error
+//	4 - Device error
+uint16_t FPS_GT511C3::SetTemplate(byte* tmplt, uint16_t id, bool duplicateCheck)
+{
+    if (UseSerialDebug) Serial.println("FPS - SetTemplate");
+	Command_Packet* cp = new Command_Packet();
+	cp->Command = Command_Packet::Commands::SetTemplate;
+	cp->ParameterFrom(0xFFFF0000 * !duplicateCheck + id); // Will set the HIWORD if duplicateCheck = false
+	uint8_t* packetbytes = cp->GetPacketBytes();
+	delete cp;
+	SendCommand(packetbytes, 12);
+    delete packetbytes;
+	Response_Packet* rp = GetResponse();
+	if(!rp->ACK)
+	{
+        delete rp;
+        return 2;
+	} else
+	{
+	    SendCommand(tmplt, 498); // Not actually a command ;)
+	    rp = GetResponse();
+	    if (rp->ACK)
+        {
+            delete rp;
+            return 0;
+        } else
+        {
+            //Change to  "retval < 3000", if using GT-521F52
+            //Leave "reval < 200", if using GT-521F32/GT-511C3
+            if (rp->FromParameter() < 200)
+            {
+                delete rp;
+                return 1;
+            }
+            uint16_t error = rp->Error;
+            delete rp;
+            if (error == Response_Packet::ErrorCodes::NACK_COMM_ERR) return 3;
+            if (error == Response_Packet::ErrorCodes::NACK_DEV_ERR) return 4;
+            return -1; // Undefined error
+        }
+	}
 }
 #ifndef __GNUC__
 #pragma endregion
@@ -777,53 +850,6 @@ bool FPS_GT511C3::GetRawImage()
 #ifndef __GNUC__
 #pragma region -= Not imlemented commands =-
 #endif  //__GNUC__
-// Gets an image that is 258x202 (52116 bytes) and returns it in 407 Data_Packets
-// Use StartDataDownload, and then GetNextDataPacket until done
-// Returns: True (device confirming download starting)
-	// Not implemented due to memory restrictions on the arduino
-	// may revisit this if I find a need for it
-//bool FPS_GT511C3::GetImage()
-//{
-	// Not implemented due to memory restrictions on the arduino
-	// may revisit this if I find a need for it
-	//return false;
-//}
-
-// Gets a template from the fps (498 bytes) in 4 Data_Packets
-// Use StartDataDownload, and then GetNextDataPacket until done
-// Parameter: 0-199 ID number
-// Returns:
-//	0 - ACK Download starting
-//	1 - Invalid position
-//	2 - ID not used (no template to download
-	// Not implemented due to memory restrictions on the arduino
-	// may revisit this if I find a need for it
-//int FPS_GT511C3::GetTemplate(int id)
-//{
-	// Not implemented due to memory restrictions on the arduino
-	// may revisit this if I find a need for it
-	//return false;
-//}
-
-// Uploads a template to the fps
-// Parameter: the template (498 bytes)
-// Parameter: the ID number to upload
-// Parameter: Check for duplicate fingerprints already on fps
-// Returns:
-//	0-199 - ID duplicated
-//	200 - Uploaded ok (no duplicate if enabled)
-//	201 - Invalid position
-//	202 - Communications error
-//	203 - Device error
-	// Not implemented due to memory restrictions on the arduino
-	// may revisit this if I find a need for it
-//int FPS_GT511C3::SetTemplate(byte* tmplt, int id, bool duplicateCheck)
-//{
-	// Not implemented due to memory restrictions on the arduino
-	// may revisit this if I find a need for it
-	//return -1;
-//}
-
 // Commands that are not implemented (and why)
 // VerifyTemplate1_1 - Couldn't find a good reason to implement this on an arduino
 // IdentifyTemplate1_N - Couldn't find a good reason to implement this on an arduino
@@ -870,22 +896,22 @@ void FPS_GT511C3::Start()
         _serial.begin(BaudRates[i]);
         _serial.listen();
         SendCommand(packetbytes, 12);
-        delay(100);
 
-        uint8_t firstbyte = 0;
-        uint8_t secondbyte = 0;
+        uint8_t firstbyte, secondbyte = 0;
         bool done = false;
         uint8_t byteCount = 0;
         while (done == false && byteCount<100)
         {
             byteCount++;
+            delay(25);
             if(_serial.peek() == -1) break;
             firstbyte = (uint8_t)_serial.read();
-            if (firstbyte == Response_Packet::COMMAND_START_CODE_1)
+            if (firstbyte == Response_Packet::RESPONSE_START_CODE_1)
             {
+                delay(25);
                 if(_serial.peek() == -1) break;
                 secondbyte = (uint8_t)_serial.read();
-                if (secondbyte == Response_Packet::COMMAND_START_CODE_2)
+                if (secondbyte == Response_Packet::RESPONSE_START_CODE_2)
                 {
                     done = true;
                 }
@@ -896,7 +922,7 @@ void FPS_GT511C3::Start()
             while (_serial.available()) _serial.read(); // Clear Serial buffer
         } else
         {
-            uint8_t* resp = new uint8_t[12];
+            uint8_t resp[12];
             resp[0] = firstbyte;
             resp[1] = secondbyte;
             for (uint8_t i=2; i < 12; i++)
@@ -913,7 +939,6 @@ void FPS_GT511C3::Start()
                 Serial.println();
                 delete rp;
             }
-            delete resp;
             actualBaud = BaudRates[i];
             break;
         }
@@ -966,26 +991,34 @@ void FPS_GT511C3::SendCommand(uint8_t cmd[], uint16_t length)
 // Gets the response to the command from the software serial channel (and waits for it)
 Response_Packet* FPS_GT511C3::GetResponse()
 {
-	uint8_t firstbyte = 0;
+	uint8_t firstbyte, secondbyte = 0;
 	bool done = false;
 	_serial.listen();
 	while (done == false)
 	{
+	    while (_serial.available() == false) delay(10);
 		firstbyte = (uint8_t)_serial.read();
-		if (firstbyte == Response_Packet::COMMAND_START_CODE_1)
+		if (firstbyte == Response_Packet::RESPONSE_START_CODE_1)
 		{
-			done = true;
+		    while (_serial.available() == false) delay(10);
+		    secondbyte = (uint8_t)_serial.read();
+		    if (secondbyte == Response_Packet::RESPONSE_START_CODE_2)
+			{
+			    done = true;
+			}
 		}
 	}
-	uint8_t* resp = new uint8_t[12];
+
+	uint8_t resp[12];
 	resp[0] = firstbyte;
-	for (uint8_t i=1; i < 12; i++)
+	resp[1] = secondbyte;
+	for (uint8_t i=2; i < 12; i++)
 	{
 		while (_serial.available() == false) delay(10);
 		resp[i]= (uint8_t) _serial.read();
 	}
+
 	Response_Packet* rp = new Response_Packet(resp, UseSerialDebug);
-	delete resp;
 	if (UseSerialDebug)
 	{
 		Serial.print("FPS - RECV: ");
@@ -1000,15 +1033,16 @@ Response_Packet* FPS_GT511C3::GetResponse()
 // and sends it over serial sommunications
 void FPS_GT511C3::GetData(uint16_t length)
 {
-	uint8_t firstbyte = 0;
-	uint8_t secondbyte = 0;
+	uint8_t firstbyte, secondbyte = 0;
 	bool done = false;
 	_serial.listen();
 	while (done == false)
 	{
+	    while (_serial.available() == false) delay(10);
 		firstbyte = (uint8_t)_serial.read();
 		if (firstbyte == Data_Packet::DATA_START_CODE_1)
 		{
+		    while (_serial.available() == false) delay(10);
 		    secondbyte = (uint8_t)_serial.read();
 		    if (secondbyte == Data_Packet::DATA_START_CODE_2)
             {
@@ -1044,14 +1078,17 @@ void FPS_GT511C3::GetData(uint16_t length)
             while (_serial.available() == false) delay(1);
             if(_serial.overflow())
             {
-                Serial.println("Overflow! Data download stopped");
-                Serial.println("Cleaning serial buffer...");
+                if(UseSerialDebug)
+                {
+                    Serial.println("Overflow! Data download stopped");
+                    Serial.println("Cleaning serial buffer...");
+                }
                 for (uint16_t j = 0; j<length; j++)
                 {
                     _serial.read();
                     delay(1);
                 }
-                Serial.println("Done!");
+                if(UseSerialDebug) Serial.println("Done!");
                 return;
             }
             data[i]= (uint8_t) _serial.read();

--- a/src/FPS_GT511C3.cpp
+++ b/src/FPS_GT511C3.cpp
@@ -602,9 +602,9 @@ uint8_t FPS_GT511C3::Enroll1()
 	{
 		if (rp->Error == Response_Packet::ErrorCodes::NACK_ENROLL_FAILED) retval = 1;
 		if (rp->Error == Response_Packet::ErrorCodes::NACK_BAD_FINGER) retval = 2;
-	}
+	} else retval = 0;
 	delete rp;
-	if (rp->ACK) return 0; else return retval;
+	return retval;
 }
 
 // Gets the Second scan of an enrollment
@@ -633,9 +633,9 @@ uint8_t FPS_GT511C3::Enroll2()
 	{
 		if (rp->Error == Response_Packet::ErrorCodes::NACK_ENROLL_FAILED) retval = 1;
 		if (rp->Error == Response_Packet::ErrorCodes::NACK_BAD_FINGER) retval = 2;
-	}
+	} else retval = 0;
 	delete rp;
-	if (rp->ACK) return 0; else return retval;
+	return retval;
 }
 
 // Gets the Third scan of an enrollment
@@ -665,9 +665,9 @@ uint8_t FPS_GT511C3::Enroll3()
 	{
 		if (rp->Error == Response_Packet::ErrorCodes::NACK_ENROLL_FAILED) retval = 1;
 		if (rp->Error == Response_Packet::ErrorCodes::NACK_BAD_FINGER) retval = 2;
-	}
+	} else retval = 0;
 	delete rp;
-	if (rp->ACK) return 0; else return retval;
+	return retval;
 }
 
 // Checks to see if a finger is pressed on the FPS

--- a/src/FPS_GT511C3.cpp
+++ b/src/FPS_GT511C3.cpp
@@ -743,7 +743,7 @@ bool FPS_GT511C3::GetImage()
 	bool retval = rp->ACK;
 	delete rp;
 	delete packetbytes;
-	GetData(52116);
+	GetData(52116+6);
 	return retval;
 
 }
@@ -766,7 +766,7 @@ bool FPS_GT511C3::GetRawImage()
 	bool retval = rp->ACK;
 	delete rp;
 	delete packetbytes;
-	GetData(19200);
+	GetData(19200+6);
 	return retval;
 
 }

--- a/src/FPS_GT511C3.cpp
+++ b/src/FPS_GT511C3.cpp
@@ -234,9 +234,9 @@ void Data_Packet::GetData(uint8_t buffer[], uint16_t length)
 }
 
 // Get the last data packet (<=128 bytes), calculate checksum, validate checksum received and send it to serial
-void Data_Packet::GetLastData(uint8_t* buffer, uint16_t length, bool UseSerialDebug)
+void Data_Packet::GetLastData(uint8_t buffer[], uint16_t length, bool UseSerialDebug)
 {
-    for(uint16_t i = 0; i<length-2, i++) Serial.write(buffer[i]);
+    for(uint16_t i = 0; i<(length-2); i++) Serial.write(buffer[i]);
         // The checksum here is arguably useless and may make the serial buffer overflow
     /*this->checksum = CalculateChecksum(buffer, length);
 	uint8_t checksum_low = GetLowByte(this->checksum);
@@ -727,11 +727,15 @@ bool FPS_GT511C3::CaptureFinger(bool highquality)
 
 // Gets an image that is 258x202 (52116 bytes) and sends it over serial
 // Returns: True (device confirming download)
+    // It only worked with baud rate at 38400-57600 in GT-511C3.
+    // Slower speeds and the FPS will shutdown. Higher speeds and the serial buffer will overflow.
+    // Make sure you are allocating enough CPU time for this task or you will overflow nonetheless.
+    // Also, avoid using UseSerialDebug for this task, since it's easier to overflow.
 bool FPS_GT511C3::GetImage()
 {
     if (UseSerialDebug) Serial.println("FPS - GetImage");
 	Command_Packet* cp = new Command_Packet();
-	cp->Command = Command_Packet::Commands::GetRawImage;
+	cp->Command = Command_Packet::Commands::GetImage;
 	uint8_t* packetbytes = cp->GetPacketBytes();
 	delete cp;
 	SendCommand(packetbytes, 12);

--- a/src/FPS_GT511C3.cpp
+++ b/src/FPS_GT511C3.cpp
@@ -92,19 +92,19 @@ Command_Packet::Command_Packet()
 // creates and parses a response packet from the finger print scanner
 Response_Packet::Response_Packet(uint8_t* buffer)
 {
-	CheckParsing(buffer[0], RESPONSE_START_CODE_1, RESPONSE_START_CODE_1, "RESPONSE_START_CODE_1");
-	CheckParsing(buffer[1], RESPONSE_START_CODE_2, RESPONSE_START_CODE_2, "RESPONSE_START_CODE_2");
-	CheckParsing(buffer[2], RESPONSE_DEVICE_ID_1, RESPONSE_DEVICE_ID_1, "RESPONSE_DEVICE_ID_1");
-	CheckParsing(buffer[3], RESPONSE_DEVICE_ID_2, RESPONSE_DEVICE_ID_2, "RESPONSE_DEVICE_ID_2");
-	CheckParsing(buffer[8], 0x30, 0x31, "AckNak_LOW");
+	CheckParsing(buffer[0], RESPONSE_START_CODE_1, RESPONSE_START_CODE_1, F("RESPONSE_START_CODE_1"));
+	CheckParsing(buffer[1], RESPONSE_START_CODE_2, RESPONSE_START_CODE_2, F("RESPONSE_START_CODE_2"));
+	CheckParsing(buffer[2], RESPONSE_DEVICE_ID_1, RESPONSE_DEVICE_ID_1, F("RESPONSE_DEVICE_ID_1"));
+	CheckParsing(buffer[3], RESPONSE_DEVICE_ID_2, RESPONSE_DEVICE_ID_2, F("RESPONSE_DEVICE_ID_2"));
+	CheckParsing(buffer[8], 0x30, 0x31, F("AckNak_LOW"));
 	if (buffer[8] == 0x30) ACK = true; else ACK = false;
-	CheckParsing(buffer[9], 0x00, 0x00, "AckNak_HIGH");
+	CheckParsing(buffer[9], 0x00, 0x00, F("AckNak_HIGH"));
 
 	uint16_t checksum = CalculateChecksum(buffer, 10);
 	uint8_t checksum_low = GetLowByte(checksum);
 	uint8_t checksum_high = GetHighByte(checksum);
-	CheckParsing(buffer[10], checksum_low, checksum_low, "Checksum_LOW");
-	CheckParsing(buffer[11], checksum_high, checksum_high, "Checksum_HIGH");
+	CheckParsing(buffer[10], checksum_low, checksum_low, F("Checksum_LOW"));
+	CheckParsing(buffer[11], checksum_high, checksum_high, F("Checksum_HIGH"));
 
 	Error = ErrorCodes::ParseFromBytes(buffer[5], buffer[4]);
 
@@ -169,19 +169,19 @@ uint32_t Response_Packet::FromParameter()
 }
 
 // checks to see if the byte is the proper value, and logs it to the serial channel if not
-bool Response_Packet::CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname)
+bool Response_Packet::CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const String varname)
 {
 	bool retval = (b != propervalue) && (b != alternatevalue);
 #if FPS_DEBUG
 	if (retval)
 	{
-		Serial.print("Response_Packet parsing error ");
+		Serial.print(F("Response_Packet parsing error "));
 		Serial.print(varname);
-		Serial.print(" ");
+		Serial.print(F(" "));
 		Serial.print(propervalue, HEX);
-		Serial.print(" || ");
+		Serial.print(F(" || "));
 		Serial.print(alternatevalue, HEX);
-		Serial.print(" != ");
+		Serial.print(F(" != "));
 		Serial.println(b, HEX);
 	}
 #endif
@@ -220,10 +220,10 @@ uint8_t Response_Packet::GetLowByte(uint16_t w)
 Data_Packet::Data_Packet(uint8_t* buffer)
 {
 #if FPS_DEBUG
-    CheckParsing(buffer[0], DATA_START_CODE_1, DATA_START_CODE_1, "DATA_START_CODE_1");
-    CheckParsing(buffer[1], DATA_START_CODE_2, DATA_START_CODE_2, "DATA_START_CODE_2");
-    CheckParsing(buffer[2], DATA_DEVICE_ID_1, DATA_DEVICE_ID_1, "DATA_DEVICE_ID_1");
-    CheckParsing(buffer[3], DATA_DEVICE_ID_2, DATA_DEVICE_ID_2, "DATA_DEVICE_ID_2");
+    CheckParsing(buffer[0], DATA_START_CODE_1, DATA_START_CODE_1, F("DATA_START_CODE_1"));
+    CheckParsing(buffer[1], DATA_START_CODE_2, DATA_START_CODE_2, F("DATA_START_CODE_2"));
+    CheckParsing(buffer[2], DATA_DEVICE_ID_1, DATA_DEVICE_ID_1, F("DATA_DEVICE_ID_1"));
+    CheckParsing(buffer[3], DATA_DEVICE_ID_2, DATA_DEVICE_ID_2, F("DATA_DEVICE_ID_2"));
 
     this->checksum = CalculateChecksum(buffer, 4);
 #endif
@@ -247,25 +247,25 @@ void Data_Packet::GetLastData(uint8_t buffer[], uint16_t length)
     this->checksum = CalculateChecksum(buffer, length-2);
     uint8_t checksum_low = GetLowByte(this->checksum);
     uint8_t checksum_high = GetHighByte(this->checksum);
-    CheckParsing(buffer[length-2], checksum_low, checksum_low, "Checksum_LOW");
-    CheckParsing(buffer[length-1], checksum_high, checksum_high, "Checksum_HIGH");
+    CheckParsing(buffer[length-2], checksum_low, checksum_low, F("Checksum_LOW"));
+    CheckParsing(buffer[length-1], checksum_high, checksum_high, F("Checksum_HIGH"));
 #endif
 }
 
 // checks to see if the byte is the proper value, and logs it to the serial channel if not
-bool Data_Packet::CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname)
+bool Data_Packet::CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const String varname)
 {
 	bool retval = (b != propervalue) && (b != alternatevalue);
 #if FPS_DEBUG
 	if(retval)
 	{
-		Serial.print("\nData_Packet parsing error ");
+		Serial.print(F("\nData_Packet parsing error "));
 		Serial.print(varname);
-		Serial.print(" ");
+		Serial.print(F(" "));
 		Serial.print(propervalue, HEX);
-		Serial.print(" || ");
+		Serial.print(F(" || "));
 		Serial.print(alternatevalue, HEX);
-		Serial.print(" != ");
+		Serial.print(F(" != "));
 		Serial.println(b, HEX);
 	}
 #endif
@@ -335,7 +335,7 @@ bool FPS_GT511C3::Open()
 {
     if (!Started) Start();
 #if FPS_DEBUG
-	Serial.println("FPS - Open");
+	Serial.println(F("FPS - Open"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Open;
@@ -359,7 +359,7 @@ bool FPS_GT511C3::Open()
 void FPS_GT511C3::Close()
 {
 #if FPS_DEBUG
-	Serial.println("FPS - Close");
+	Serial.println(F("FPS - Close"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Close;
@@ -385,14 +385,14 @@ bool FPS_GT511C3::SetLED(bool on)
 	if (on)
 	{
 #if FPS_DEBUG
-		Serial.println("FPS - LED on");
+		Serial.println(F("FPS - LED on"));
 #endif
 		cp->Parameter[0] = 0x01;
 	}
 	else
 	{
 #if FPS_DEBUG
-		Serial.println("FPS - LED off");
+		Serial.println(F("FPS - LED off"));
 #endif
 		cp->Parameter[0] = 0x00;
 	}
@@ -419,7 +419,7 @@ bool FPS_GT511C3::ChangeBaudRate(uint32_t baud)
     if ((baud == 9600) || (baud == 19200) || (baud == 38400) || (baud == 57600) || (baud == 115200))
 	{
 #if FPS_DEBUG
-        Serial.println("FPS - ChangeBaudRate");
+        Serial.println(F("FPS - ChangeBaudRate"));
 #endif
 		Command_Packet* cp = new Command_Packet();
 		cp->Command = Command_Packet::Commands::ChangeBaudRate;
@@ -442,7 +442,7 @@ bool FPS_GT511C3::ChangeBaudRate(uint32_t baud)
 uint16_t FPS_GT511C3::GetEnrollCount()
 {
 #if FPS_DEBUG
-	Serial.println("FPS - GetEnrolledCount");
+	Serial.println(F("FPS - GetEnrolledCount"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::GetEnrollCount;
@@ -467,7 +467,7 @@ uint16_t FPS_GT511C3::GetEnrollCount()
 bool FPS_GT511C3::CheckEnrolled(uint16_t id)
 {
 #if FPS_DEBUG
-	Serial.println("FPS - CheckEnrolled");
+	Serial.println(F("FPS - CheckEnrolled"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::CheckEnrolled;
@@ -494,7 +494,7 @@ bool FPS_GT511C3::CheckEnrolled(uint16_t id)
 uint8_t FPS_GT511C3::EnrollStart(uint16_t id)
 {
 #if FPS_DEBUG
-	Serial.println("FPS - EnrollStart");
+	Serial.println(F("FPS - EnrollStart"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::EnrollStart;
@@ -524,7 +524,7 @@ uint8_t FPS_GT511C3::EnrollStart(uint16_t id)
 uint8_t FPS_GT511C3::Enroll1()
 {
 #if FPS_DEBUG
-	Serial.println("FPS - Enroll1");
+	Serial.println(F("FPS - Enroll1"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Enroll1;
@@ -555,7 +555,7 @@ uint8_t FPS_GT511C3::Enroll1()
 uint8_t FPS_GT511C3::Enroll2()
 {
 #if FPS_DEBUG
-	Serial.println("FPS - Enroll2");
+	Serial.println(F("FPS - Enroll2"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Enroll2;
@@ -587,7 +587,7 @@ uint8_t FPS_GT511C3::Enroll2()
 uint8_t FPS_GT511C3::Enroll3()
 {
 #if FPS_DEBUG
-	Serial.println("FPS - Enroll3");
+	Serial.println(F("FPS - Enroll3"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Enroll3;
@@ -614,7 +614,7 @@ uint8_t FPS_GT511C3::Enroll3()
 bool FPS_GT511C3::IsPressFinger()
 {
 #if FPS_DEBUG
-	Serial.println("FPS - IsPressFinger");
+	Serial.println(F("FPS - IsPressFinger"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::IsPressFinger;
@@ -636,7 +636,7 @@ bool FPS_GT511C3::IsPressFinger()
 bool FPS_GT511C3::DeleteID(uint16_t id)
 {
 #if FPS_DEBUG
-	Serial.println("FPS - DeleteID");
+	Serial.println(F("FPS - DeleteID"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::DeleteID;
@@ -656,7 +656,7 @@ bool FPS_GT511C3::DeleteID(uint16_t id)
 bool FPS_GT511C3::DeleteAll()
 {
 #if FPS_DEBUG
-	Serial.println("FPS - DeleteAll");
+	Serial.println(F("FPS - DeleteAll"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::DeleteAll;
@@ -681,7 +681,7 @@ bool FPS_GT511C3::DeleteAll()
 uint8_t FPS_GT511C3::Verify1_1(uint16_t id)
 {
 #if FPS_DEBUG
-	Serial.println("FPS - Verify1_1");
+	Serial.println(F("FPS - Verify1_1"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Verify1_1;
@@ -714,7 +714,7 @@ uint8_t FPS_GT511C3::Verify1_1(uint16_t id)
 uint16_t FPS_GT511C3::Identify1_N()
 {
 #if FPS_DEBUG
-	Serial.println("FPS - Identify1_N");
+	Serial.println(F("FPS - Identify1_N"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Identify1_N;
@@ -738,7 +738,7 @@ uint16_t FPS_GT511C3::Identify1_N()
 bool FPS_GT511C3::CaptureFinger(bool highquality)
 {
 #if FPS_DEBUG
-	Serial.println("FPS - CaptureFinger");
+	Serial.println(F("FPS - CaptureFinger"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::CaptureFinger;
@@ -772,7 +772,7 @@ bool FPS_GT511C3::CaptureFinger(bool highquality)
 bool FPS_GT511C3::GetImage(bool patched)
 {
 #if FPS_DEBUG
-	Serial.println("FPS - GetImage");
+	Serial.println(F("FPS - GetImage"));
 #endif
     Command_Packet* cp = new Command_Packet();
     cp->Command = Command_Packet::Commands::GetImage;
@@ -816,7 +816,7 @@ bool FPS_GT511C3::GetImage(bool patched)
 bool FPS_GT511C3::GetRawImage()
 {
 #if FPS_DEBUG
-	Serial.println("FPS - GetRawImage");
+	Serial.println(F("FPS - GetRawImage"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::GetRawImage;
@@ -840,7 +840,7 @@ bool FPS_GT511C3::GetRawImage()
 uint8_t FPS_GT511C3::GetTemplate(uint16_t id)
 {
 #if FPS_DEBUG
-	Serial.println("FPS - GetTemplate");
+	Serial.println(F("FPS - GetTemplate"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::GetTemplate;
@@ -873,7 +873,7 @@ uint8_t FPS_GT511C3::GetTemplate(uint16_t id)
 uint8_t FPS_GT511C3::GetTemplate(uint16_t id, uint8_t data[])
 {
 #if FPS_DEBUG
-	Serial.println("FPS - GetTemplate");
+	Serial.println(F("FPS - GetTemplate"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::GetTemplate;
@@ -910,7 +910,7 @@ uint8_t FPS_GT511C3::GetTemplate(uint16_t id, uint8_t data[])
 uint16_t FPS_GT511C3::SetTemplate(byte* tmplt, uint16_t id, bool duplicateCheck)
 {
 #if FPS_DEBUG
-	Serial.println("FPS - SetTemplate");
+	Serial.println(F("FPS - SetTemplate"));
 #endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::SetTemplate;
@@ -994,7 +994,7 @@ void FPS_GT511C3::Start()
 	for(uint8_t i = 0; i<5; i++) // Trying to find FPS baud rate
     {
 #if FPS_DEBUG
-        Serial.print("Establishing connection with FPS at baud rate: ");
+        Serial.print(F("Establishing connection with FPS at baud rate: "));
         Serial.print(BaudRates[i]);
         Serial.println();
 #endif
@@ -1050,7 +1050,7 @@ void FPS_GT511C3::Start()
     }
 
 #if FPS_DEBUG
-	Serial.print("Connection established succesfully. FPS baud rate was: ");
+	Serial.print(F("Connection established succesfully. FPS baud rate was: "));
 	Serial.print(actualBaud);
 	Serial.println();
 	Serial.println();
@@ -1059,7 +1059,7 @@ void FPS_GT511C3::Start()
     if (actualBaud == 0) while(true)
     {
 #if FPS_DEBUG
-		Serial.print("EXCEPTION: FPS didn't answer to communications. Code execution stopped.");
+		Serial.print(F("EXCEPTION: FPS didn't answer to communications. Code execution stopped."));
 		Serial.println();
 #endif
         delay(1000); // Something went terribly wrong with the FPS, and you aren't allowed to leave
@@ -1068,7 +1068,7 @@ void FPS_GT511C3::Start()
     if (actualBaud != baud)
     {
 #if FPS_DEBUG
-		Serial.print("Undesired baud rate. Changing baud rate to: ");
+		Serial.print(F("Undesired baud rate. Changing baud rate to: "));
 		Serial.print(baud);
 		Serial.println();
 		Serial.println();
@@ -1083,7 +1083,7 @@ void FPS_GT511C3::SendCommand(uint8_t cmd[], uint16_t length)
 {
 	_serial.write(cmd, length);
 #if FPS_DEBUG
-	Serial.print("FPS - SEND: ");
+	Serial.print(F("FPS - SEND: "));
 	SendToSerial(cmd, length);
 	Serial.println();
 #endif
@@ -1179,8 +1179,8 @@ void FPS_GT511C3::GetData(uint16_t length)
             if(_serial.overflow())
             {
 #if FPS_DEBUG
-				Serial.println("Overflow! Data download stopped");
-				Serial.println("Cleaning serial buffer...");
+				Serial.println(F("Overflow! Data download stopped"));
+				Serial.println(F("Cleaning serial buffer..."));
 #endif
                 for (uint16_t j = 0; j<length; j++)
                 {
@@ -1188,7 +1188,7 @@ void FPS_GT511C3::GetData(uint16_t length)
                     delay(1);
                 }
 #if FPS_DEBUG
-				Serial.println("Done!");
+				Serial.println(F("Done!"));
 #endif
 				return;
             }
@@ -1245,8 +1245,8 @@ bool FPS_GT511C3::ReturnData(uint16_t length, uint8_t data[])
             if(_serial.overflow())
             {
 #if FPS_DEBUG
-				Serial.println("Overflow! Data download stopped");
-				Serial.println("Cleaning serial buffer...");
+				Serial.println(F("Overflow! Data download stopped"));
+				Serial.println(F("Cleaning serial buffer..."));
 #endif
                 for (uint16_t j = 0; j<length; j++)
                 {
@@ -1254,7 +1254,7 @@ bool FPS_GT511C3::ReturnData(uint16_t length, uint8_t data[])
                     delay(1);
                 }
 #if FPS_DEBUG
-				Serial.println("Done!");
+				Serial.println(F("Done!"));
 #endif
 				return false;
             }

--- a/src/FPS_GT511C3.cpp
+++ b/src/FPS_GT511C3.cpp
@@ -1162,12 +1162,12 @@ void FPS_GT511C3::GetData(uint16_t length)
 	Data_Packet dp(firstdata);
 
 	uint16_t numberPacketsNeeded = (length-4) / 64;
-	bool smallLastPacket = false;
 	uint8_t lastPacketSize = (length-4) % 64;
-	if(lastPacketSize != 0)
-	{
-		numberPacketsNeeded++;
-		smallLastPacket = true;
+	if(lastPacketSize != 0) numberPacketsNeeded++;
+	else {
+		// Last packet requires special treatment, so you don't want it to pass over the main loop
+		numberPacketsNeeded--;
+		lastPacketSize = 64;
 	}
 
     uint8_t data[64];
@@ -1237,16 +1237,7 @@ bool FPS_GT511C3::ReturnData(uint16_t length, uint8_t data[])
 		while (_serial.available() == false) delay(10);
 		firstdata[i]= (uint8_t) _serial.read();
 	}
-	Data_Packet dp(firstdata);
-
-	uint16_t numberPacketsNeeded = (length-4) / 64;
-	bool smallLastPacket = false;
-	uint8_t lastPacketSize = (length-4) % 64;
-	if(lastPacketSize != 0)
-	{
-		numberPacketsNeeded++;
-		smallLastPacket = true;
-	}
+	Data_Packet dp(firstdata); // Not needed
 
 	for (uint16_t i=0; i < length-4; i++)
         {

--- a/src/FPS_GT511C3.cpp
+++ b/src/FPS_GT511C3.cpp
@@ -962,12 +962,12 @@ uint8_t FPS_GT511C3::GetTemplate(uint16_t id, uint8_t data[])
 // Parameter: the ID number to upload
 // Parameter: Check for duplicate fingerprints already on fps
 // Returns:
-// -1 - Undefined error (shouldn't ever happen)
 //	0 - Uploaded ok (no duplicate if enabled)
 //	1 - ID duplicated
 //	2 - Invalid position
 //	3 - Communications error
 //	4 - Device error
+//	5 - Undefined error (shouldn't ever happen)
 uint16_t FPS_GT511C3::SetTemplate(uint8_t tmplt[], uint16_t id, bool duplicateCheck)
 {
 #if FPS_DEBUG
@@ -1006,7 +1006,7 @@ uint16_t FPS_GT511C3::SetTemplate(uint8_t tmplt[], uint16_t id, bool duplicateCh
             delete rp;
             if (error == Response_Packet::ErrorCodes::NACK_COMM_ERR) return 3;
             if (error == Response_Packet::ErrorCodes::NACK_DEV_ERR) return 4;
-            return -1; // Undefined error
+            return 5; // Undefined error
         }
 	}
 }

--- a/src/FPS_GT511C3.cpp
+++ b/src/FPS_GT511C3.cpp
@@ -988,6 +988,7 @@ uint16_t FPS_GT511C3::SetTemplate(uint8_t tmplt[], uint16_t id, bool duplicateCh
 	} else
 	{
 		Data_Packet dp(tmplt, 498, _serial); // This makes the data packet and sends it immediately
+		delete rp;
 	    rp = GetResponse();
 	    if (rp->ACK)
         {

--- a/src/FPS_GT511C3.cpp
+++ b/src/FPS_GT511C3.cpp
@@ -229,16 +229,16 @@ Data_Packet::Data_Packet(uint8_t* buffer)
 #endif
 }
 
-// Get a data packet (128 bytes), calculate checksum and send it to serial
-void Data_Packet::GetData(uint8_t buffer[])
+// Get a data packet, calculate checksum and send it to serial
+void Data_Packet::GetData(uint8_t buffer[], uint16_t length)
 {
-    for(uint16_t i = 0; i<128; i++) Serial.write(buffer[i]);
+    for(uint16_t i = 0; i<length; i++) Serial.write(buffer[i]);
 #if FPS_DEBUG
-	this->checksum = CalculateChecksum(buffer, 128);
+	this->checksum = CalculateChecksum(buffer, length);
 #endif
 }
 
-// Get the last data packet (<=128 bytes), calculate checksum, validate checksum received and send it to serial
+// Get the last data packet, calculate checksum, validate checksum received and send it to serial
 void Data_Packet::GetLastData(uint8_t buffer[], uint16_t length)
 {
     for(uint16_t i = 0; i<length; i++) Serial.write(buffer[i]);
@@ -1128,19 +1128,19 @@ void FPS_GT511C3::GetData(uint16_t length)
 	}
 	Data_Packet dp(firstdata);
 
-	uint16_t numberPacketsNeeded = (length-4) / 128;
+	uint16_t numberPacketsNeeded = (length-4) / 64;
 	bool smallLastPacket = false;
-	uint8_t lastPacketSize = (length-4) % 128;
+	uint8_t lastPacketSize = (length-4) % 64;
 	if(lastPacketSize != 0)
 	{
-            numberPacketsNeeded++;
-            smallLastPacket = true;
+		numberPacketsNeeded++;
+		smallLastPacket = true;
 	}
 
-    uint8_t data[128];
+    uint8_t data[64];
 	for (uint16_t packetCount=1; packetCount < numberPacketsNeeded; packetCount++)
     {
-        for (uint8_t i=0; i < 128; i++)
+        for (uint8_t i=0; i < 64; i++)
         {
             while (_serial.available() == false) delay(1);
             if(_serial.overflow())
@@ -1161,7 +1161,7 @@ void FPS_GT511C3::GetData(uint16_t length)
             }
             data[i]= (uint8_t) _serial.read();
         }
-        dp.GetData(data);
+        dp.GetData(data, 64);
 	}
 
 	uint8_t lastdata[lastPacketSize];

--- a/src/FPS_GT511C3.cpp
+++ b/src/FPS_GT511C3.cpp
@@ -218,7 +218,7 @@ uint8_t Response_Packet::GetLowByte(uint16_t w)
 #pragma region -= Data_Packet =-
 #endif  //__GNUC__
 // creates a data packet and send it to the finger print scanner
-Data_Packet::Data_Packet(uint8_t buffer[], uint16_t length, SoftwareSerial _serial)
+Data_Packet::Data_Packet(uint8_t buffer[], uint16_t length, SoftwareSerial& _serial)
 {
 	
 	uint8_t* data_code= new uint8_t[4];
@@ -1110,6 +1110,7 @@ void FPS_GT511C3::Start()
             break;
         }
     }
+	delete packetbytes;
 
 #if FPS_DEBUG
 	Serial.print(F("Connection established succesfully. FPS baud rate was: "));

--- a/src/FPS_GT511C3.cpp
+++ b/src/FPS_GT511C3.cpp
@@ -90,21 +90,21 @@ Command_Packet::Command_Packet()
 #pragma region -= Response_Packet Definitions =-
 #endif  //__GNUC__
 // creates and parses a response packet from the finger print scanner
-Response_Packet::Response_Packet(uint8_t* buffer, bool UseSerialDebug)
+Response_Packet::Response_Packet(uint8_t* buffer)
 {
-	CheckParsing(buffer[0], RESPONSE_START_CODE_1, RESPONSE_START_CODE_1, "RESPONSE_START_CODE_1", UseSerialDebug);
-	CheckParsing(buffer[1], RESPONSE_START_CODE_2, RESPONSE_START_CODE_2, "RESPONSE_START_CODE_2", UseSerialDebug);
-	CheckParsing(buffer[2], RESPONSE_DEVICE_ID_1, RESPONSE_DEVICE_ID_1, "RESPONSE_DEVICE_ID_1", UseSerialDebug);
-	CheckParsing(buffer[3], RESPONSE_DEVICE_ID_2, RESPONSE_DEVICE_ID_2, "RESPONSE_DEVICE_ID_2", UseSerialDebug);
-	CheckParsing(buffer[8], 0x30, 0x31, "AckNak_LOW", UseSerialDebug);
+	CheckParsing(buffer[0], RESPONSE_START_CODE_1, RESPONSE_START_CODE_1, "RESPONSE_START_CODE_1");
+	CheckParsing(buffer[1], RESPONSE_START_CODE_2, RESPONSE_START_CODE_2, "RESPONSE_START_CODE_2");
+	CheckParsing(buffer[2], RESPONSE_DEVICE_ID_1, RESPONSE_DEVICE_ID_1, "RESPONSE_DEVICE_ID_1");
+	CheckParsing(buffer[3], RESPONSE_DEVICE_ID_2, RESPONSE_DEVICE_ID_2, "RESPONSE_DEVICE_ID_2");
+	CheckParsing(buffer[8], 0x30, 0x31, "AckNak_LOW");
 	if (buffer[8] == 0x30) ACK = true; else ACK = false;
-	CheckParsing(buffer[9], 0x00, 0x00, "AckNak_HIGH", UseSerialDebug);
+	CheckParsing(buffer[9], 0x00, 0x00, "AckNak_HIGH");
 
 	uint16_t checksum = CalculateChecksum(buffer, 10);
 	uint8_t checksum_low = GetLowByte(checksum);
 	uint8_t checksum_high = GetHighByte(checksum);
-	CheckParsing(buffer[10], checksum_low, checksum_low, "Checksum_LOW", UseSerialDebug);
-	CheckParsing(buffer[11], checksum_high, checksum_high, "Checksum_HIGH", UseSerialDebug);
+	CheckParsing(buffer[10], checksum_low, checksum_low, "Checksum_LOW");
+	CheckParsing(buffer[11], checksum_high, checksum_high, "Checksum_HIGH");
 
 	Error = ErrorCodes::ParseFromBytes(buffer[5], buffer[4]);
 
@@ -169,10 +169,11 @@ uint32_t Response_Packet::FromParameter()
 }
 
 // checks to see if the byte is the proper value, and logs it to the serial channel if not
-bool Response_Packet::CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname, bool UseSerialDebug)
+bool Response_Packet::CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname)
 {
 	bool retval = (b != propervalue) && (b != alternatevalue);
-	if ((UseSerialDebug) && (retval))
+#if FPS_DEBUG
+	if (retval)
 	{
 		Serial.print("Response_Packet parsing error ");
 		Serial.print(varname);
@@ -183,6 +184,7 @@ bool Response_Packet::CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alter
 		Serial.print(" != ");
 		Serial.println(b, HEX);
 	}
+#endif
   return retval;
 }
 
@@ -215,45 +217,47 @@ uint8_t Response_Packet::GetLowByte(uint16_t w)
 #ifndef __GNUC__
 #pragma region -= Data_Packet =-
 #endif  //__GNUC__
-Data_Packet::Data_Packet(uint8_t* buffer, bool UseSerialDebug)
+Data_Packet::Data_Packet(uint8_t* buffer)
 {
-    if (UseSerialDebug)
-    {
-        CheckParsing(buffer[0], DATA_START_CODE_1, DATA_START_CODE_1, "DATA_START_CODE_1", UseSerialDebug);
-        CheckParsing(buffer[1], DATA_START_CODE_2, DATA_START_CODE_2, "DATA_START_CODE_2", UseSerialDebug);
-        CheckParsing(buffer[2], DATA_DEVICE_ID_1, DATA_DEVICE_ID_1, "DATA_DEVICE_ID_1", UseSerialDebug);
-        CheckParsing(buffer[3], DATA_DEVICE_ID_2, DATA_DEVICE_ID_2, "DATA_DEVICE_ID_2", UseSerialDebug);
+#if FPS_DEBUG
+    CheckParsing(buffer[0], DATA_START_CODE_1, DATA_START_CODE_1, "DATA_START_CODE_1");
+    CheckParsing(buffer[1], DATA_START_CODE_2, DATA_START_CODE_2, "DATA_START_CODE_2");
+    CheckParsing(buffer[2], DATA_DEVICE_ID_1, DATA_DEVICE_ID_1, "DATA_DEVICE_ID_1");
+    CheckParsing(buffer[3], DATA_DEVICE_ID_2, DATA_DEVICE_ID_2, "DATA_DEVICE_ID_2");
 
-        this->checksum = CalculateChecksum(buffer, 4);
-    }
+    this->checksum = CalculateChecksum(buffer, 4);
+#endif
 }
 
 // Get a data packet (128 bytes), calculate checksum and send it to serial
-void Data_Packet::GetData(uint8_t buffer[], uint16_t length, bool UseSerialDebug)
+void Data_Packet::GetData(uint8_t buffer[])
 {
-    for(uint16_t i = 0; i<length; i++) Serial.write(buffer[i]);
-    if (UseSerialDebug) this->checksum = CalculateChecksum(buffer, 128);
+    for(uint16_t i = 0; i<128; i++) Serial.write(buffer[i]);
+#if FPS_DEBUG
+	this->checksum = CalculateChecksum(buffer, 128);
+#endif
 }
 
 // Get the last data packet (<=128 bytes), calculate checksum, validate checksum received and send it to serial
-void Data_Packet::GetLastData(uint8_t buffer[], uint16_t length, bool UseSerialDebug)
+void Data_Packet::GetLastData(uint8_t buffer[], uint16_t length)
 {
     for(uint16_t i = 0; i<length; i++) Serial.write(buffer[i]);
-    if (UseSerialDebug)
-    {
-        this->checksum = CalculateChecksum(buffer, length-2);
-        uint8_t checksum_low = GetLowByte(this->checksum);
-        uint8_t checksum_high = GetHighByte(this->checksum);
-        CheckParsing(buffer[length-2], checksum_low, checksum_low, "Checksum_LOW", UseSerialDebug);
-        CheckParsing(buffer[length-1], checksum_high, checksum_high, "Checksum_HIGH", UseSerialDebug);
-    }
+
+#if FPS_DEBUG
+    this->checksum = CalculateChecksum(buffer, length-2);
+    uint8_t checksum_low = GetLowByte(this->checksum);
+    uint8_t checksum_high = GetHighByte(this->checksum);
+    CheckParsing(buffer[length-2], checksum_low, checksum_low, "Checksum_LOW");
+    CheckParsing(buffer[length-1], checksum_high, checksum_high, "Checksum_HIGH");
+#endif
 }
 
 // checks to see if the byte is the proper value, and logs it to the serial channel if not
-bool Data_Packet::CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname, bool UseSerialDebug)
+bool Data_Packet::CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname)
 {
 	bool retval = (b != propervalue) && (b != alternatevalue);
-	if ((UseSerialDebug) && (retval))
+#if FPS_DEBUG
+	if(retval)
 	{
 		Serial.print("\nData_Packet parsing error ");
 		Serial.print(varname);
@@ -264,6 +268,7 @@ bool Data_Packet::CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternate
 		Serial.print(" != ");
 		Serial.println(b, HEX);
 	}
+#endif
   return retval;
 }
 
@@ -308,7 +313,6 @@ FPS_GT511C3::FPS_GT511C3(uint8_t rx, uint8_t tx, uint32_t baud)
 {
 	pin_RX = rx;
 	pin_TX = tx;
-	this->UseSerialDebug = false;
     this->Started = false;
     desiredBaud = baud;
 };
@@ -330,7 +334,9 @@ FPS_GT511C3::~FPS_GT511C3()
 bool FPS_GT511C3::Open()
 {
     if (!Started) Start();
-	if (UseSerialDebug) Serial.println("FPS - Open");
+#if FPS_DEBUG
+	Serial.println("FPS - Open");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Open;
 	cp->Parameter[0] = 0x00;
@@ -352,7 +358,9 @@ bool FPS_GT511C3::Open()
 // Implemented it for completeness.
 void FPS_GT511C3::Close()
 {
-	if (UseSerialDebug) Serial.println("FPS - Close");
+#if FPS_DEBUG
+	Serial.println("FPS - Close");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Close;
 	cp->Parameter[0] = 0x00;
@@ -376,12 +384,16 @@ bool FPS_GT511C3::SetLED(bool on)
 	cp->Command = Command_Packet::Commands::CmosLed;
 	if (on)
 	{
-		if (UseSerialDebug) Serial.println("FPS - LED on");
+#if FPS_DEBUG
+		Serial.println("FPS - LED on");
+#endif
 		cp->Parameter[0] = 0x01;
 	}
 	else
 	{
-		if (UseSerialDebug) Serial.println("FPS - LED off");
+#if FPS_DEBUG
+		Serial.println("FPS - LED off");
+#endif
 		cp->Parameter[0] = 0x00;
 	}
 	cp->Parameter[1] = 0x00;
@@ -406,7 +418,9 @@ bool FPS_GT511C3::ChangeBaudRate(uint32_t baud)
 {
     if ((baud == 9600) || (baud == 19200) || (baud == 38400) || (baud == 57600) || (baud == 115200))
 	{
-        if (UseSerialDebug) Serial.println("FPS - ChangeBaudRate");
+#if FPS_DEBUG
+        Serial.println("FPS - ChangeBaudRate");
+#endif
 		Command_Packet* cp = new Command_Packet();
 		cp->Command = Command_Packet::Commands::ChangeBaudRate;
 		cp->ParameterFrom(baud);
@@ -427,7 +441,9 @@ bool FPS_GT511C3::ChangeBaudRate(uint32_t baud)
 // Return: The total number of enrolled fingerprints
 uint16_t FPS_GT511C3::GetEnrollCount()
 {
-	if (UseSerialDebug) Serial.println("FPS - GetEnrolledCount");
+#if FPS_DEBUG
+	Serial.println("FPS - GetEnrolledCount");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::GetEnrollCount;
 	cp->Parameter[0] = 0x00;
@@ -450,7 +466,9 @@ uint16_t FPS_GT511C3::GetEnrollCount()
 // Return: True if the ID number is enrolled, false if not
 bool FPS_GT511C3::CheckEnrolled(uint16_t id)
 {
-	if (UseSerialDebug) Serial.println("FPS - CheckEnrolled");
+#if FPS_DEBUG
+	Serial.println("FPS - CheckEnrolled");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::CheckEnrolled;
 	cp->ParameterFrom(id);
@@ -475,7 +493,9 @@ bool FPS_GT511C3::CheckEnrolled(uint16_t id)
 //	3 - Position(ID) is already used
 uint8_t FPS_GT511C3::EnrollStart(uint16_t id)
 {
-	if (UseSerialDebug) Serial.println("FPS - EnrollStart");
+#if FPS_DEBUG
+	Serial.println("FPS - EnrollStart");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::EnrollStart;
 	cp->ParameterFrom(id);
@@ -503,7 +523,9 @@ uint8_t FPS_GT511C3::EnrollStart(uint16_t id)
 //	3 - ID in use
 uint8_t FPS_GT511C3::Enroll1()
 {
-	if (UseSerialDebug) Serial.println("FPS - Enroll1");
+#if FPS_DEBUG
+	Serial.println("FPS - Enroll1");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Enroll1;
 	uint8_t* packetbytes = cp->GetPacketBytes();
@@ -532,7 +554,9 @@ uint8_t FPS_GT511C3::Enroll1()
 //	3 - ID in use
 uint8_t FPS_GT511C3::Enroll2()
 {
-	if (UseSerialDebug) Serial.println("FPS - Enroll2");
+#if FPS_DEBUG
+	Serial.println("FPS - Enroll2");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Enroll2;
 	byte* packetbytes = cp->GetPacketBytes();
@@ -562,7 +586,9 @@ uint8_t FPS_GT511C3::Enroll2()
 //	3 - ID in use
 uint8_t FPS_GT511C3::Enroll3()
 {
-	if (UseSerialDebug) Serial.println("FPS - Enroll3");
+#if FPS_DEBUG
+	Serial.println("FPS - Enroll3");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Enroll3;
 	byte* packetbytes = cp->GetPacketBytes();
@@ -587,7 +613,9 @@ uint8_t FPS_GT511C3::Enroll3()
 // Return: true if finger pressed, false if not
 bool FPS_GT511C3::IsPressFinger()
 {
-	if (UseSerialDebug) Serial.println("FPS - IsPressFinger");
+#if FPS_DEBUG
+	Serial.println("FPS - IsPressFinger");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::IsPressFinger;
 	uint8_t* packetbytes = cp->GetPacketBytes();
@@ -607,7 +635,9 @@ bool FPS_GT511C3::IsPressFinger()
 // Returns: true if successful, false if position invalid
 bool FPS_GT511C3::DeleteID(uint16_t id)
 {
-	if (UseSerialDebug) Serial.println("FPS - DeleteID");
+#if FPS_DEBUG
+	Serial.println("FPS - DeleteID");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::DeleteID;
 	cp->ParameterFrom(id);
@@ -625,7 +655,9 @@ bool FPS_GT511C3::DeleteID(uint16_t id)
 // Returns: true if successful, false if db is empty
 bool FPS_GT511C3::DeleteAll()
 {
-	if (UseSerialDebug) Serial.println("FPS - DeleteAll");
+#if FPS_DEBUG
+	Serial.println("FPS - DeleteAll");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::DeleteAll;
 	uint8_t* packetbytes = cp->GetPacketBytes();
@@ -648,7 +680,9 @@ bool FPS_GT511C3::DeleteAll()
 //	3 - Verified FALSE (not the correct finger)
 uint8_t FPS_GT511C3::Verify1_1(uint16_t id)
 {
-	if (UseSerialDebug) Serial.println("FPS - Verify1_1");
+#if FPS_DEBUG
+	Serial.println("FPS - Verify1_1");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Verify1_1;
 	cp->ParameterFrom(id);
@@ -679,7 +713,9 @@ uint8_t FPS_GT511C3::Verify1_1(uint16_t id)
 //           200, if using GT-521F32/GT-511C3
 uint16_t FPS_GT511C3::Identify1_N()
 {
-	if (UseSerialDebug) Serial.println("FPS - Identify1_N");
+#if FPS_DEBUG
+	Serial.println("FPS - Identify1_N");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::Identify1_N;
 	uint8_t* packetbytes = cp->GetPacketBytes();
@@ -701,7 +737,9 @@ uint16_t FPS_GT511C3::Identify1_N()
 // Returns: True if ok, false if no finger pressed
 bool FPS_GT511C3::CaptureFinger(bool highquality)
 {
-	if (UseSerialDebug) Serial.println("FPS - CaptureFinger");
+#if FPS_DEBUG
+	Serial.println("FPS - CaptureFinger");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::CaptureFinger;
 	if (highquality)
@@ -733,7 +771,9 @@ bool FPS_GT511C3::CaptureFinger(bool highquality)
 // Parameter: true to ignore the documentation and get valid image data.
 bool FPS_GT511C3::GetImage(bool patched)
 {
-    if (UseSerialDebug) Serial.println("FPS - GetImage");
+#if FPS_DEBUG
+	Serial.println("FPS - GetImage");
+#endif
     Command_Packet* cp = new Command_Packet();
     cp->Command = Command_Packet::Commands::GetImage;
     uint8_t* packetbytes = cp->GetPacketBytes();
@@ -775,7 +815,9 @@ bool FPS_GT511C3::GetImage(bool patched)
     // Also, avoid using UseSerialDebug for this task, since it's easier to overflow.
 bool FPS_GT511C3::GetRawImage()
 {
-    if (UseSerialDebug) Serial.println("FPS - GetRawImage");
+#if FPS_DEBUG
+	Serial.println("FPS - GetRawImage");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::GetRawImage;
 	uint8_t* packetbytes = cp->GetPacketBytes();
@@ -797,7 +839,9 @@ bool FPS_GT511C3::GetRawImage()
 //	2 - ID not used (no template to download
 uint8_t FPS_GT511C3::GetTemplate(uint16_t id)
 {
-    if (UseSerialDebug) Serial.println("FPS - GetTemplate");
+#if FPS_DEBUG
+	Serial.println("FPS - GetTemplate");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::GetTemplate;
 	cp->ParameterFrom(id);
@@ -832,7 +876,9 @@ uint8_t FPS_GT511C3::GetTemplate(uint16_t id)
 //	4 - Device error
 uint16_t FPS_GT511C3::SetTemplate(byte* tmplt, uint16_t id, bool duplicateCheck)
 {
-    if (UseSerialDebug) Serial.println("FPS - SetTemplate");
+#if FPS_DEBUG
+	Serial.println("FPS - SetTemplate");
+#endif
 	Command_Packet* cp = new Command_Packet();
 	cp->Command = Command_Packet::Commands::SetTemplate;
 	cp->ParameterFrom(0xFFFF0000 * !duplicateCheck + id); // Will set the HIWORD if duplicateCheck = false
@@ -914,12 +960,12 @@ void FPS_GT511C3::Start()
 	uint32_t BaudRates[5] = {9600, 19200, 38400, 57600, 115200};
 	for(uint8_t i = 0; i<5; i++) // Trying to find FPS baud rate
     {
-        if(UseSerialDebug)
-        {
-            Serial.print("Establishing connection with FPS at baud rate: ");
-            Serial.print(BaudRates[i]);
-            Serial.println();
-        }
+#if FPS_DEBUG
+        Serial.print("Establishing connection with FPS at baud rate: ");
+        Serial.print(BaudRates[i]);
+        Serial.println();
+#endif
+
         _serial.begin(BaudRates[i]);
         _serial.listen();
         SendCommand(packetbytes, 12);
@@ -957,47 +1003,43 @@ void FPS_GT511C3::Start()
                 while (_serial.available() == false) delay(10);
                 resp[i]= (uint8_t) _serial.read();
             }
-            if (UseSerialDebug)
-            {
-                Response_Packet* rp = new Response_Packet(resp, UseSerialDebug);
-                Serial.print("FPS - RECV: ");
-                SendToSerial(rp->RawBytes, 12);
-                Serial.println();
-                Serial.println();
-                delete rp;
-            }
+#if FPS_DEBUG
+			Response_Packet* rp = new Response_Packet(resp);
+			Serial.print("FPS - RECV: ");
+			SendToSerial(rp->RawBytes, 12);
+			Serial.println();
+			Serial.println();
+			delete rp;
+#endif
             actualBaud = BaudRates[i];
             break;
         }
     }
 
-    if(UseSerialDebug)
-    {
-        Serial.print("Connection established succesfully. FPS baud rate was: ");
-        Serial.print(actualBaud);
-        Serial.println();
-        Serial.println();
-    }
+#if FPS_DEBUG
+	Serial.print("Connection established succesfully. FPS baud rate was: ");
+	Serial.print(actualBaud);
+	Serial.println();
+	Serial.println();
+#endif
 
     if (actualBaud == 0) while(true)
     {
-        if(UseSerialDebug)
-        {
-            Serial.print("EXCEPTION: FPS didn't answer to communications. Code execution stopped.");
-            Serial.println();
-        }
+#if FPS_DEBUG
+		Serial.print("EXCEPTION: FPS didn't answer to communications. Code execution stopped.");
+		Serial.println();
+#endif
         delay(1000); // Something went terribly wrong with the FPS, and you aren't allowed to leave
     }
 
     if (actualBaud != baud)
     {
-        if(UseSerialDebug)
-        {
-            Serial.print("Undesired baud rate. Changing baud rate to: ");
-            Serial.print(baud);
-            Serial.println();
-            Serial.println();
-        }
+#if FPS_DEBUG
+		Serial.print("Undesired baud rate. Changing baud rate to: ");
+		Serial.print(baud);
+		Serial.println();
+		Serial.println();
+#endif
         ChangeBaudRate(baud);
     }
     Started = true;
@@ -1007,12 +1049,11 @@ void FPS_GT511C3::Start()
 void FPS_GT511C3::SendCommand(uint8_t cmd[], uint16_t length)
 {
 	_serial.write(cmd, length);
-	if (UseSerialDebug)
-	{
-		Serial.print("FPS - SEND: ");
-		SendToSerial(cmd, length);
-		Serial.println();
-	}
+#if FPS_DEBUG
+	Serial.print("FPS - SEND: ");
+	SendToSerial(cmd, length);
+	Serial.println();
+#endif
 };
 
 // Gets the response to the command from the software serial channel (and waits for it)
@@ -1045,14 +1086,13 @@ Response_Packet* FPS_GT511C3::GetResponse()
 		resp[i]= (uint8_t) _serial.read();
 	}
 
-	Response_Packet* rp = new Response_Packet(resp, UseSerialDebug);
-	if (UseSerialDebug)
-	{
-		Serial.print("FPS - RECV: ");
-		SendToSerial(rp->RawBytes, 12);
-		Serial.println();
-		Serial.println();
-	}
+	Response_Packet* rp = new Response_Packet(resp);
+#if FPS_DEBUG
+	Serial.print("FPS - RECV: ");
+	SendToSerial(rp->RawBytes, 12);
+	Serial.println();
+	Serial.println();
+#endif
 	return rp;
 };
 
@@ -1086,7 +1126,7 @@ void FPS_GT511C3::GetData(uint16_t length)
 		while (_serial.available() == false) delay(10);
 		firstdata[i]= (uint8_t) _serial.read();
 	}
-	Data_Packet dp(firstdata, UseSerialDebug);
+	Data_Packet dp(firstdata);
 
 	uint16_t numberPacketsNeeded = (length-4) / 128;
 	bool smallLastPacket = false;
@@ -1105,22 +1145,23 @@ void FPS_GT511C3::GetData(uint16_t length)
             while (_serial.available() == false) delay(1);
             if(_serial.overflow())
             {
-                if(UseSerialDebug)
-                {
-                    Serial.println("Overflow! Data download stopped");
-                    Serial.println("Cleaning serial buffer...");
-                }
+#if FPS_DEBUG
+				Serial.println("Overflow! Data download stopped");
+				Serial.println("Cleaning serial buffer...");
+#endif
                 for (uint16_t j = 0; j<length; j++)
                 {
                     _serial.read();
                     delay(1);
                 }
-                if(UseSerialDebug) Serial.println("Done!");
-                return;
+#if FPS_DEBUG
+				Serial.println("Done!");
+#endif
+				return;
             }
             data[i]= (uint8_t) _serial.read();
         }
-        dp.GetData(data, 128, UseSerialDebug);
+        dp.GetData(data);
 	}
 
 	uint8_t lastdata[lastPacketSize];
@@ -1129,7 +1170,7 @@ void FPS_GT511C3::GetData(uint16_t length)
 		while (_serial.available() == false) delay(10);
 		lastdata[i]= (uint8_t) _serial.read();
 	}
-	dp.GetLastData(lastdata, lastPacketSize, UseSerialDebug);
+	dp.GetLastData(lastdata, lastPacketSize);
 };
 
 // sends the byte array to the serial debugger in our hex format EX: "00 AF FF 10 00 13"

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -157,15 +157,13 @@ public:
     static const uint8_t DATA_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
     static const uint8_t DATA_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)
 
-    void GetData(uint8_t* buffer, bool UseSerialDebug);
-	void GetLastData(uint8_t* buffer, uint16_t length, bool UseSerialDebug);
+    void GetData(uint8_t buffer[], uint16_t length);
+	void GetLastData(uint8_t buffer[], uint16_t length, bool UseSerialDebug);
 private:
 	bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname, bool UseSerialDebug);
 	uint16_t CalculateChecksum(uint8_t* buffer, uint16_t length);
     uint8_t GetHighByte(uint16_t w);
     uint8_t GetLowByte(uint16_t w);
-    void serialPrintHex(uint8_t data);
-    void SendToSerial(uint8_t data[], uint16_t length);
 };
 #ifndef __GNUC__
 #pragma endregion

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -321,6 +321,14 @@ class FPS_GT511C3
 	//	1 - Invalid position
 	//	2 - ID not used (no template to download
 	uint8_t GetTemplate(uint16_t id);
+	
+	// Gets a template from the fps (498 bytes + 2 bytes checksum) and store it in an array
+	// Parameter: 0-199 ID number, array pointer to store the data
+	// Returns:
+	//	0 - ACK Download starting
+	//	1 - Invalid position
+	//	2 - ID not used (no template to download
+	uint8_t GetTemplate(uint16_t id, uint8_t data[]);
 
 	// Uploads a template to the fps
 	// Parameter: the template (498 bytes)
@@ -374,6 +382,7 @@ private:
     void SendCommand(uint8_t cmd[], uint16_t length);
     Response_Packet* GetResponse();
     void GetData(uint16_t length);
+	bool ReturnData(uint16_t length, uint8_t data[]);
     uint8_t pin_RX,pin_TX;
     SoftwareSerial _serial;
 };

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -29,7 +29,7 @@ class Command_Packet
 					Open				= 0x01,		// Open Initialization
 					Close				= 0x02,		// Close Termination
 					UsbInternalCheck	= 0x03,		// UsbInternalCheck Check if the connected USB device is valid
-					ChangeEBaudRate		= 0x04,		// ChangeBaudrate Change UART baud rate
+					ChangeBaudRate		= 0x04,		// ChangeBaudrate Change UART baud rate
 					SetIAPMode			= 0x05,		// SetIAPMode Enter IAP Mode In this mode, FW Upgrade is available
 					CmosLed				= 0x12,		// CmosLed Control CMOS LED
 					GetEnrollCount		= 0x20,		// Get enrolled fingerprint count

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -126,10 +126,10 @@ class Response_Packet
 		uint8_t ParameterBytes[4];
 		uint8_t ResponseBytes[2];
 		bool ACK;
-		static const uint8_t COMMAND_START_CODE_1 = 0x55;	// Static byte to mark the beginning of a command packet	-	never changes
-		static const uint8_t COMMAND_START_CODE_2 = 0xAA;	// Static byte to mark the beginning of a command packet	-	never changes
-		static const uint8_t COMMAND_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
-		static const uint8_t COMMAND_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)							-	theoretically never changes
+		static const uint8_t RESPONSE_START_CODE_1 = 0x55;	// Static byte to mark the beginning of a command packet	-	never changes
+		static const uint8_t RESPONSE_START_CODE_2 = 0xAA;	// Static byte to mark the beginning of a command packet	-	never changes
+		static const uint8_t RESPONSE_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
+		static const uint8_t RESPONSE_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)							-	theoretically never changes
 		uint32_t FromParameter();
 
 	private:
@@ -307,6 +307,27 @@ class FPS_GT511C3
 	// Gets an image that is qvga 160x120 (19200 bytes) and sends it over serial
     // Returns: True (device confirming download)
 	bool GetRawImage();
+
+    // Gets a template from the fps (498 bytes)
+	// Parameter: 0-199 ID number
+	// Returns:
+	//	0 - ACK Download starting
+	//	1 - Invalid position
+	//	2 - ID not used (no template to download
+	uint8_t GetTemplate(uint16_t id);
+
+	// Uploads a template to the fps
+	// Parameter: the template (498 bytes)
+	// Parameter: the ID number to upload
+	// Parameter: Check for duplicate fingerprints already on fps
+    // Returns:
+    // -1 - Undefined error (shouldn't ever happen)
+    //	0 - Uploaded ok (no duplicate if enabled)
+    //	1 - ID duplicated
+    //	2 - Invalid position
+    //	3 - Communications error
+    //	4 - Device error
+	uint16_t SetTemplate(byte* tmplt, uint16_t id, bool duplicateCheck);
 #ifndef __GNUC__
 	#pragma endregion
 #endif  //__GNUC__
@@ -314,31 +335,6 @@ class FPS_GT511C3
 #ifndef __GNUC__
 	#pragma region -= Not implemented commands =-
 #endif  //__GNUC__
-	// Gets a template from the fps (498 bytes) in 4 Data_Packets
-	// Use StartDataDownload, and then GetNextDataPacket until done
-	// Parameter: 0-199 ID number
-	// Returns:
-	//	0 - ACK Download starting
-	//	1 - Invalid position
-	//	2 - ID not used (no template to download
-	// Not implemented due to memory restrictions on the arduino
-	// may revisit this if I find a need for it
-	//int GetTemplate(int id);
-
-	// Uploads a template to the fps
-	// Parameter: the template (498 bytes)
-	// Parameter: the ID number to upload
-	// Parameter: Check for duplicate fingerprints already on fps
-	// Returns:
-	//	0-199 - ID duplicated
-	//	200 - Uploaded ok (no duplicate if enabled)
-	//	201 - Invalid position
-	//	202 - Communications error
-	//	203 - Device error
-	// Not implemented due to memory restrictions on the arduino
-	// may revisit this if I find a need for it
-	//int SetTemplate(byte* tmplt, int id, bool duplicateCheck);
-
 	// Commands that are not implemented (and why)
 	// VerifyTemplate1_1 - Couldn't find a good reason to implement this on an arduino
 	// IdentifyTemplate1_N - Couldn't find a good reason to implement this on an arduino

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -181,11 +181,13 @@ class FPS_GT511C3
  public:
 	// Enables verbose debug output using hardware Serial
 	bool UseSerialDebug;
+	uint32_t desiredBaud;
 
 #ifndef __GNUC__
 	#pragma region -= Constructor/Destructor =-
 #endif  //__GNUC__
 	// Creates a new object to interface with the fingerprint scanner
+	// It will establish the communication to the desired baud rate if defined
 	FPS_GT511C3(uint8_t rx, uint8_t tx, uint32_t baud = 9600);
 
 	// destructor
@@ -199,7 +201,8 @@ class FPS_GT511C3
 	#pragma region -= Device Commands =-
 #endif  //__GNUC__
 	//Initialises the device and gets ready for commands
-	void Open();
+	//Returns true if the communication established
+	bool Open();
 
 	// Does not actually do anything (according to the datasheet)
 	// I implemented open, so had to do closed too... lol
@@ -361,11 +364,18 @@ class FPS_GT511C3
 	void SendToSerial(uint8_t data[], uint16_t length);
 
 private:
-	 void SendCommand(uint8_t cmd[], uint16_t length);
-	 Response_Packet* GetResponse();
-	 void GetData(uint16_t length);
-	 uint8_t pin_RX,pin_TX;
-	 SoftwareSerial _serial;
+
+    // Indicates if the communication was configured for the first time
+	bool Started;
+
+    //Configures the device correctly for communications at the desired baud rate
+    void Start();
+
+    void SendCommand(uint8_t cmd[], uint16_t length);
+    Response_Packet* GetResponse();
+    void GetData(uint16_t length);
+    uint8_t pin_RX,pin_TX;
+    SoftwareSerial _serial;
 };
 
 

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -336,12 +336,12 @@ class FPS_GT511C3
 	// Parameter: the ID number to upload
 	// Parameter: Check for duplicate fingerprints already on fps
     // Returns:
-    // -1 - Undefined error (shouldn't ever happen)
     //	0 - Uploaded ok (no duplicate if enabled)
     //	1 - ID duplicated
     //	2 - Invalid position
     //	3 - Communications error
     //	4 - Device error
+	//	5 - Undefined error (shouldn't ever happen)
 	uint16_t SetTemplate(uint8_t tmplt[], uint16_t id, bool duplicateCheck);
 #ifndef __GNUC__
 	#pragma endregion

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -61,22 +61,22 @@ class Command_Packet
 		};
 
 		Commands::Commands_Enum Command;
-		byte Parameter[4];								// Parameter 4 bytes, changes meaning depending on command
-		byte* GetPacketBytes();							// returns the bytes to be transmitted
-		void ParameterFromInt(int i);
+		uint8_t Parameter[4];								// Parameter 4 bytes, changes meaning depending on command
+		uint8_t* GetPacketBytes();							// returns the bytes to be transmitted
+		void ParameterFrom(uint32_t u);
 
 		Command_Packet();
 
 	private:
-		static const byte COMMAND_START_CODE_1 = 0x55;	// Static byte to mark the beginning of a command packet	-	never changes
-		static const byte COMMAND_START_CODE_2 = 0xAA;	// Static byte to mark the beginning of a command packet	-	never changes
-		static const byte COMMAND_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
-		static const byte COMMAND_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)							-	theoretically never changes
-		byte command[2];								// Command 2 bytes
+		static const uint8_t COMMAND_START_CODE_1 = 0x55;	// Static byte to mark the beginning of a command packet	-	never changes
+		static const uint8_t COMMAND_START_CODE_2 = 0xAA;	// Static byte to mark the beginning of a command packet	-	never changes
+		static const uint8_t COMMAND_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
+		static const uint8_t COMMAND_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)							-	theoretically never changes
+		uint8_t command[2];								// Command 2 bytes
 
-		word _CalculateChecksum();						// Checksum is calculated using byte addition
-		byte GetHighByte(word w);
-		byte GetLowByte(word w);
+		uint16_t _CalculateChecksum();						// Checksum is calculated using byte addition
+		uint8_t GetHighByte(word w);
+		uint8_t GetLowByte(word w);
 };
 #ifndef __GNUC__
 #pragma endregion
@@ -120,23 +120,23 @@ class Response_Packet
 
 				static Errors_Enum ParseFromBytes(byte high, byte low);
 		};
-		Response_Packet(byte* buffer, bool UseSerialDebug);
+		Response_Packet(uint8_t* buffer, bool UseSerialDebug);
 		ErrorCodes::Errors_Enum Error;
-		byte RawBytes[12];
-		byte ParameterBytes[4];
-		byte ResponseBytes[2];
+		uint8_t RawBytes[12];
+		uint8_t ParameterBytes[4];
+		uint8_t ResponseBytes[2];
 		bool ACK;
-		static const byte COMMAND_START_CODE_1 = 0x55;	// Static byte to mark the beginning of a command packet	-	never changes
-		static const byte COMMAND_START_CODE_2 = 0xAA;	// Static byte to mark the beginning of a command packet	-	never changes
-		static const byte COMMAND_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
-		static const byte COMMAND_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)							-	theoretically never changes
-		int IntFromParameter();
+		static const uint8_t COMMAND_START_CODE_1 = 0x55;	// Static byte to mark the beginning of a command packet	-	never changes
+		static const uint8_t COMMAND_START_CODE_2 = 0xAA;	// Static byte to mark the beginning of a command packet	-	never changes
+		static const uint8_t COMMAND_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
+		static const uint8_t COMMAND_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)							-	theoretically never changes
+		uint32_t FromParameter();
 
 	private:
-		bool CheckParsing(byte b, byte propervalue, byte alternatevalue, const char* varname, bool UseSerialDebug);
-		word CalculateChecksum(byte* buffer, int length);
-		byte GetHighByte(word w);
-		byte GetLowByte(word w);
+		bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname, bool UseSerialDebug);
+		uint16_t CalculateChecksum(uint8_t* buffer, uint16_t length);
+		uint8_t GetHighByte(uint16_t w);
+		uint8_t GetLowByte(uint16_t w);
 };
 #ifndef __GNUC__
 #pragma endregion
@@ -150,22 +150,22 @@ class Response_Packet
 class Data_Packet
 {
 public:
-    Data_Packet(byte* buffer, bool UseSerialDebug);
-    word checksum = 0;
-    static const byte DATA_START_CODE_1 = 0x5A;	// Static byte to mark the beginning of a data packet	-	never changes
-    static const byte DATA_START_CODE_2 = 0xA5;	// Static byte to mark the beginning of a data packet	-	never changes
-    static const byte DATA_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
-    static const byte DATA_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)
+    Data_Packet(uint8_t* buffer, bool UseSerialDebug);
+    uint16_t checksum = 0;
+    static const uint8_t DATA_START_CODE_1 = 0x5A;	// Static byte to mark the beginning of a data packet	-	never changes
+    static const uint8_t DATA_START_CODE_2 = 0xA5;	// Static byte to mark the beginning of a data packet	-	never changes
+    static const uint8_t DATA_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
+    static const uint8_t DATA_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)
 
-    void GetData(byte* buffer, bool UseSerialDebug);
-	void GetLastData(byte* buffer, int length, bool UseSerialDebug);
+    void GetData(uint8_t* buffer, bool UseSerialDebug);
+	void GetLastData(uint8_t* buffer, uint16_t length, bool UseSerialDebug);
 private:
-	bool CheckParsing(byte b, byte propervalue, byte alternatevalue, const char* varname, bool UseSerialDebug);
-	word CalculateChecksum(byte* buffer, int length);
-    byte GetHighByte(word w);
-    byte GetLowByte(word w);
-    void serialPrintHex(byte data);
-    void SendToSerial(byte data[], int length);
+	bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname, bool UseSerialDebug);
+	uint16_t CalculateChecksum(uint8_t* buffer, uint16_t length);
+    uint8_t GetHighByte(uint16_t w);
+    uint8_t GetLowByte(uint16_t w);
+    void serialPrintHex(uint8_t data);
+    void SendToSerial(uint8_t data[], uint16_t length);
 };
 #ifndef __GNUC__
 #pragma endregion
@@ -186,7 +186,7 @@ class FPS_GT511C3
 	#pragma region -= Constructor/Destructor =-
 #endif  //__GNUC__
 	// Creates a new object to interface with the fingerprint scanner
-	FPS_GT511C3(uint8_t rx, uint8_t tx);
+	FPS_GT511C3(uint8_t rx, uint8_t tx, uint32_t baud = 9600);
 
 	// destructor
 	~FPS_GT511C3();
@@ -214,18 +214,17 @@ class FPS_GT511C3
 	// Changes the baud rate of the connection
 	// Parameter: 9600 - 115200
 	// Returns: True if success, false if invalid baud
-	// NOTE: Untested (don't have a logic level changer and a voltage divider is too slow)
-	bool ChangeBaudRate(unsigned long baud);
+	bool ChangeBaudRate(uint32_t baud);
 
 	// Gets the number of enrolled fingerprints
 	// Return: The total number of enrolled fingerprints
-	int GetEnrollCount();
+	uint16_t GetEnrollCount();
 
 	// checks to see if the ID number is in use or not
 	// Parameter: 0-2999, if using GT-521F52
         //            0-199, if using GT-521F32/GT-511C3
 	// Return: True if the ID number is enrolled, false if not
-	bool CheckEnrolled(int id);
+	bool CheckEnrolled(uint16_t id);
 
 	// Starts the Enrollment Process
 	// Parameter: 0-2999, if using GT-521F52
@@ -235,7 +234,7 @@ class FPS_GT511C3
 	//	1 - Database is full
 	//	2 - Invalid Position
 	//	3 - Position(ID) is already used
-	int EnrollStart(int id);
+	uint8_t EnrollStart(uint16_t id);
 
 	// Gets the first scan of an enrollment
 	// Return:
@@ -243,7 +242,7 @@ class FPS_GT511C3
 	//	1 - Enroll Failed
 	//	2 - Bad finger
 	//	3 - ID in use
-	int Enroll1();
+	uint8_t Enroll1();
 
 	// Gets the Second scan of an enrollment
 	// Return:
@@ -251,7 +250,7 @@ class FPS_GT511C3
 	//	1 - Enroll Failed
 	//	2 - Bad finger
 	//	3 - ID in use
-	int Enroll2();
+	uint8_t Enroll2();
 
 	// Gets the Third scan of an enrollment
 	// Finishes Enrollment
@@ -260,7 +259,7 @@ class FPS_GT511C3
 	//	1 - Enroll Failed
 	//	2 - Bad finger
 	//	3 - ID in use
-	int Enroll3();
+	uint8_t Enroll3();
 
 	// Checks to see if a finger is pressed on the FPS
 	// Return: true if finger pressed, false if not
@@ -268,7 +267,7 @@ class FPS_GT511C3
 
 	// Deletes the specified ID (enrollment) from the database
 	// Returns: true if successful, false if position invalid
-	bool DeleteID(int ID);
+	bool DeleteID(uint16_t ID);
 
 	// Deletes all IDs (enrollments) from the database
 	// Returns: true if successful, false if db is empty
@@ -282,7 +281,7 @@ class FPS_GT511C3
 	//	1 - Invalid Position
 	//	2 - ID is not in use
 	//	3 - Verified FALSE (not the correct finger)
-	int Verify1_1(int id);
+	uint8_t Verify1_1(uint16_t id);
 
 	// Checks the currently pressed finger against all enrolled fingerprints
 	// Returns:
@@ -292,7 +291,7 @@ class FPS_GT511C3
         //      Failed to find the fingerprint in the database
         // 	     3000, if using GT-521F52
         //           200, if using GT-521F32/GT-511C3
-	int Identify1_N();
+	uint16_t Identify1_N();
 
 	// Captures the currently pressed finger into onboard ram
 	// Parameter: true for high quality image(slower), false for low quality image (faster)
@@ -358,13 +357,13 @@ class FPS_GT511C3
 	#pragma endregion
 #endif  //__GNUC__
 
-	void serialPrintHex(byte data);
-	void SendToSerial(byte data[], int length);
+	void serialPrintHex(uint8_t data);
+	void SendToSerial(uint8_t data[], uint16_t length);
 
 private:
-	 void SendCommand(byte cmd[], int length);
+	 void SendCommand(uint8_t cmd[], uint16_t length);
 	 Response_Packet* GetResponse();
-	 void GetData(int length);
+	 void GetData(uint16_t length);
 	 uint8_t pin_RX,pin_TX;
 	 SoftwareSerial _serial;
 };

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -11,6 +11,12 @@
 
 #include "Arduino.h"
 #include "SoftwareSerial.h"
+
+// Debug level:
+//  0: Disabled
+//  1: Enables verbose debug output using hardware Serial
+#define FPS_DEBUG 0
+
 #ifndef __GNUC__
 #pragma region -= Command_Packet =-
 #endif  //__GNUC__
@@ -120,7 +126,7 @@ class Response_Packet
 
 				static Errors_Enum ParseFromBytes(byte high, byte low);
 		};
-		Response_Packet(uint8_t* buffer, bool UseSerialDebug);
+		Response_Packet(uint8_t* buffer);
 		ErrorCodes::Errors_Enum Error;
 		uint8_t RawBytes[12];
 		uint8_t ParameterBytes[4];
@@ -133,7 +139,7 @@ class Response_Packet
 		uint32_t FromParameter();
 
 	private:
-		bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname, bool UseSerialDebug);
+		bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname);
 		uint16_t CalculateChecksum(uint8_t* buffer, uint16_t length);
 		uint8_t GetHighByte(uint16_t w);
 		uint8_t GetLowByte(uint16_t w);
@@ -150,17 +156,17 @@ class Response_Packet
 class Data_Packet
 {
 public:
-    Data_Packet(uint8_t* buffer, bool UseSerialDebug);
+    Data_Packet(uint8_t* buffer);
     uint16_t checksum = 0;
     static const uint8_t DATA_START_CODE_1 = 0x5A;	// Static byte to mark the beginning of a data packet	-	never changes
     static const uint8_t DATA_START_CODE_2 = 0xA5;	// Static byte to mark the beginning of a data packet	-	never changes
     static const uint8_t DATA_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
     static const uint8_t DATA_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)
 
-    void GetData(uint8_t buffer[], uint16_t length, bool UseSerialDebug);
-	void GetLastData(uint8_t buffer[], uint16_t length, bool UseSerialDebug);
+    void GetData(uint8_t buffer[]);
+	void GetLastData(uint8_t buffer[], uint16_t length);
 private:
-	bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname, bool UseSerialDebug);
+	bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname);
 	uint16_t CalculateChecksum(uint8_t* buffer, uint16_t length);
     uint8_t GetHighByte(uint16_t w);
     uint8_t GetLowByte(uint16_t w);
@@ -177,8 +183,6 @@ class FPS_GT511C3
 {
 
  public:
-	// Enables verbose debug output using hardware Serial
-	bool UseSerialDebug;
 	uint32_t desiredBaud;
 
 #ifndef __GNUC__

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -301,8 +301,10 @@ class FPS_GT511C3
 	bool CaptureFinger(bool highquality);
 
     // Gets an image that is 258x202 (52116 bytes + 2 bytes checksum) and sends it over serial
+    // WARNING: The documentation is totally wrong (at least in GT-511C3). Check implementation comments.
     // Returns: True (device confirming download)
-	bool GetImage();
+    // Parameter: true to ignore the documentation and get valid image data.
+	bool GetImage(bool patched = false);
 
 	// Gets an image that is qvga 160x120 (19200 bytes + 2 bytes checksum) and sends it over serial
     // Returns: True (device confirming download)

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -163,7 +163,7 @@ public:
     static const uint8_t DATA_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
     static const uint8_t DATA_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)
 
-    void GetData(uint8_t buffer[]);
+    void GetData(uint8_t buffer[], uint16_t length);
 	void GetLastData(uint8_t buffer[], uint16_t length);
 private:
 	bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname);

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -303,19 +303,13 @@ class FPS_GT511C3
 #ifndef __GNUC__
 	#pragma region -= Not implemented commands =-
 #endif  //__GNUC__
-	// Gets an image that is 258x202 (52116 bytes) and returns it in 407 Data_Packets
-	// Use StartDataDownload, and then GetNextDataPacket until done
-	// Returns: True (device confirming download starting)
-	// Not implemented due to memory restrictions on the arduino
-	// may revisit this if I find a need for it
-	//bool GetImage();
+	// Gets an image that is 258x202 (52116 bytes) and sends it over serial
+    // Returns: True (device confirming download)
+	bool GetImage();
 
-	// Gets an image that is qvga 160x120 (19200 bytes) and returns it in 150 Data_Packets
-	// Use StartDataDownload, and then GetNextDataPacket until done
-	// Returns: True (device confirming download starting)
-	// Not implemented due to memory restrictions on the arduino
-	// may revisit this if I find a need for it
-	//bool GetRawImage();
+	// Gets an image that is qvga 160x120 (19200 bytes) and sends it over serial
+    // Returns: True (device confirming download)
+	bool GetRawImage();
 
 	// Gets a template from the fps (498 bytes) in 4 Data_Packets
 	// Use StartDataDownload, and then GetNextDataPacket until done

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -157,7 +157,7 @@ public:
     static const uint8_t DATA_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
     static const uint8_t DATA_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)
 
-    void GetData(uint8_t buffer[], uint16_t length);
+    void GetData(uint8_t buffer[], uint16_t length, bool UseSerialDebug);
 	void GetLastData(uint8_t buffer[], uint16_t length, bool UseSerialDebug);
 private:
 	bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname, bool UseSerialDebug);
@@ -300,15 +300,15 @@ class FPS_GT511C3
 	// Returns: True if ok, false if no finger pressed
 	bool CaptureFinger(bool highquality);
 
-    // Gets an image that is 258x202 (52116 bytes) and sends it over serial
+    // Gets an image that is 258x202 (52116 bytes + 2 bytes checksum) and sends it over serial
     // Returns: True (device confirming download)
 	bool GetImage();
 
-	// Gets an image that is qvga 160x120 (19200 bytes) and sends it over serial
+	// Gets an image that is qvga 160x120 (19200 bytes + 2 bytes checksum) and sends it over serial
     // Returns: True (device confirming download)
 	bool GetRawImage();
 
-    // Gets a template from the fps (498 bytes)
+    // Gets a template from the fps (498 bytes + 2 bytes checksum)
 	// Parameter: 0-199 ID number
 	// Returns:
 	//	0 - ACK Download starting

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -139,7 +139,7 @@ class Response_Packet
 		uint32_t FromParameter();
 
 	private:
-		bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname);
+		bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const String varname);
 		uint16_t CalculateChecksum(uint8_t* buffer, uint16_t length);
 		uint8_t GetHighByte(uint16_t w);
 		uint8_t GetLowByte(uint16_t w);
@@ -166,7 +166,7 @@ public:
     void GetData(uint8_t buffer[], uint16_t length);
 	void GetLastData(uint8_t buffer[], uint16_t length);
 private:
-	bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname);
+	bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const String varname);
 	uint16_t CalculateChecksum(uint8_t* buffer, uint16_t length);
     uint8_t GetHighByte(uint16_t w);
     uint8_t GetLowByte(uint16_t w);

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -15,7 +15,7 @@
 // Debug level:
 //  0: Disabled
 //  1: Enables verbose debug output using hardware Serial
-#define FPS_DEBUG 0
+#define FPS_DEBUG 1
 
 #ifndef __GNUC__
 #pragma region -= Command_Packet =-
@@ -126,7 +126,7 @@ class Response_Packet
 
 				static Errors_Enum ParseFromBytes(byte high, byte low);
 		};
-		Response_Packet(uint8_t* buffer);
+		Response_Packet(uint8_t buffer[]);
 		ErrorCodes::Errors_Enum Error;
 		uint8_t RawBytes[12];
 		uint8_t ParameterBytes[4];
@@ -140,7 +140,7 @@ class Response_Packet
 
 	private:
 		bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const String varname);
-		uint16_t CalculateChecksum(uint8_t* buffer, uint16_t length);
+		uint16_t CalculateChecksum(uint8_t buffer[], uint16_t length);
 		uint8_t GetHighByte(uint16_t w);
 		uint8_t GetLowByte(uint16_t w);
 };
@@ -156,7 +156,8 @@ class Response_Packet
 class Data_Packet
 {
 public:
-    Data_Packet(uint8_t* buffer);
+	Data_Packet(uint8_t buffer[], uint16_t length, SoftwareSerial _serial);
+    Data_Packet(uint8_t buffer[]);
     uint16_t checksum = 0;
     static const uint8_t DATA_START_CODE_1 = 0x5A;	// Static byte to mark the beginning of a data packet	-	never changes
     static const uint8_t DATA_START_CODE_2 = 0xA5;	// Static byte to mark the beginning of a data packet	-	never changes
@@ -167,7 +168,7 @@ public:
 	void GetLastData(uint8_t buffer[], uint16_t length);
 private:
 	bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const String varname);
-	uint16_t CalculateChecksum(uint8_t* buffer, uint16_t length);
+	uint16_t CalculateChecksum(uint8_t buffer[], uint16_t length);
     uint8_t GetHighByte(uint16_t w);
     uint8_t GetLowByte(uint16_t w);
 };
@@ -341,7 +342,7 @@ class FPS_GT511C3
     //	2 - Invalid position
     //	3 - Communications error
     //	4 - Device error
-	uint16_t SetTemplate(byte* tmplt, uint16_t id, bool duplicateCheck);
+	uint16_t SetTemplate(uint8_t tmplt[], uint16_t id, bool duplicateCheck);
 #ifndef __GNUC__
 	#pragma endregion
 #endif  //__GNUC__

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -11,6 +11,12 @@
 
 #include "Arduino.h"
 #include "SoftwareSerial.h"
+
+// Debug level:
+//  0: Disabled
+//  1: Enables verbose debug output using hardware Serial
+#define FPS_DEBUG 0
+
 #ifndef __GNUC__
 #pragma region -= Command_Packet =-
 #endif  //__GNUC__
@@ -120,7 +126,7 @@ class Response_Packet
 
 				static Errors_Enum ParseFromBytes(byte high, byte low);
 		};
-		Response_Packet(uint8_t* buffer, bool UseSerialDebug);
+		Response_Packet(uint8_t* buffer);
 		ErrorCodes::Errors_Enum Error;
 		uint8_t RawBytes[12];
 		uint8_t ParameterBytes[4];
@@ -133,7 +139,7 @@ class Response_Packet
 		uint32_t FromParameter();
 
 	private:
-		bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname, bool UseSerialDebug);
+		bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const String varname);
 		uint16_t CalculateChecksum(uint8_t* buffer, uint16_t length);
 		uint8_t GetHighByte(uint16_t w);
 		uint8_t GetLowByte(uint16_t w);
@@ -150,17 +156,17 @@ class Response_Packet
 class Data_Packet
 {
 public:
-    Data_Packet(uint8_t* buffer, bool UseSerialDebug);
+    Data_Packet(uint8_t* buffer);
     uint16_t checksum = 0;
     static const uint8_t DATA_START_CODE_1 = 0x5A;	// Static byte to mark the beginning of a data packet	-	never changes
     static const uint8_t DATA_START_CODE_2 = 0xA5;	// Static byte to mark the beginning of a data packet	-	never changes
     static const uint8_t DATA_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
     static const uint8_t DATA_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)
 
-    void GetData(uint8_t buffer[], uint16_t length, bool UseSerialDebug);
-	void GetLastData(uint8_t buffer[], uint16_t length, bool UseSerialDebug);
+    void GetData(uint8_t buffer[], uint16_t length);
+	void GetLastData(uint8_t buffer[], uint16_t length);
 private:
-	bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const char* varname, bool UseSerialDebug);
+	bool CheckParsing(uint8_t b, uint8_t propervalue, uint8_t alternatevalue, const String varname);
 	uint16_t CalculateChecksum(uint8_t* buffer, uint16_t length);
     uint8_t GetHighByte(uint16_t w);
     uint8_t GetLowByte(uint16_t w);
@@ -177,8 +183,6 @@ class FPS_GT511C3
 {
 
  public:
-	// Enables verbose debug output using hardware Serial
-	bool UseSerialDebug;
 	uint32_t desiredBaud;
 
 #ifndef __GNUC__
@@ -317,6 +321,14 @@ class FPS_GT511C3
 	//	1 - Invalid position
 	//	2 - ID not used (no template to download
 	uint8_t GetTemplate(uint16_t id);
+	
+	// Gets a template from the fps (498 bytes + 2 bytes checksum) and store it in an array
+	// Parameter: 0-199 ID number, array pointer to store the data
+	// Returns:
+	//	0 - ACK Download starting
+	//	1 - Invalid position
+	//	2 - ID not used (no template to download
+	uint8_t GetTemplate(uint16_t id, uint8_t data[]);
 
 	// Uploads a template to the fps
 	// Parameter: the template (498 bytes)
@@ -370,6 +382,7 @@ private:
     void SendCommand(uint8_t cmd[], uint16_t length);
     Response_Packet* GetResponse();
     void GetData(uint16_t length);
+	bool ReturnData(uint16_t length, uint8_t data[]);
     uint8_t pin_RX,pin_TX;
     SoftwareSerial _serial;
 };

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -156,7 +156,7 @@ class Response_Packet
 class Data_Packet
 {
 public:
-	Data_Packet(uint8_t buffer[], uint16_t length, SoftwareSerial _serial);
+	Data_Packet(uint8_t buffer[], uint16_t length, SoftwareSerial& _serial);
     Data_Packet(uint8_t buffer[]);
     uint16_t checksum = 0;
     static const uint8_t DATA_START_CODE_1 = 0x5A;	// Static byte to mark the beginning of a data packet	-	never changes

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -156,13 +156,16 @@ public:
     static const byte DATA_START_CODE_2 = 0xA5;	// Static byte to mark the beginning of a data packet	-	never changes
     static const byte DATA_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
     static const byte DATA_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)
-private:
-	void GetData(byte* buffer, bool UseSerialDebug);
+
+    void GetData(byte* buffer, bool UseSerialDebug);
 	void GetLastData(byte* buffer, int length, bool UseSerialDebug);
+private:
 	bool CheckParsing(byte b, byte propervalue, byte alternatevalue, const char* varname, bool UseSerialDebug);
 	word CalculateChecksum(byte* buffer, int length);
     byte GetHighByte(word w);
     byte GetLowByte(word w);
+    void serialPrintHex(byte data);
+    void SendToSerial(byte data[], int length);
 };
 #ifndef __GNUC__
 #pragma endregion

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -299,6 +299,14 @@ class FPS_GT511C3
 	// Generally, use high quality for enrollment, and low quality for verification/identification
 	// Returns: True if ok, false if no finger pressed
 	bool CaptureFinger(bool highquality);
+
+    // Gets an image that is 258x202 (52116 bytes) and sends it over serial
+    // Returns: True (device confirming download)
+	bool GetImage();
+
+	// Gets an image that is qvga 160x120 (19200 bytes) and sends it over serial
+    // Returns: True (device confirming download)
+	bool GetRawImage();
 #ifndef __GNUC__
 	#pragma endregion
 #endif  //__GNUC__
@@ -306,14 +314,6 @@ class FPS_GT511C3
 #ifndef __GNUC__
 	#pragma region -= Not implemented commands =-
 #endif  //__GNUC__
-	// Gets an image that is 258x202 (52116 bytes) and sends it over serial
-    // Returns: True (device confirming download)
-	bool GetImage();
-
-	// Gets an image that is qvga 160x120 (19200 bytes) and sends it over serial
-    // Returns: True (device confirming download)
-	bool GetRawImage();
-
 	// Gets a template from the fps (498 bytes) in 4 Data_Packets
 	// Use StartDataDownload, and then GetNextDataPacket until done
 	// Parameter: 0-199 ID number

--- a/src/FPS_GT511C3.h
+++ b/src/FPS_GT511C3.h
@@ -61,13 +61,13 @@ class Command_Packet
 		};
 
 		Commands::Commands_Enum Command;
-		byte Parameter[4];								// Parameter 4 bytes, changes meaning depending on command							
+		byte Parameter[4];								// Parameter 4 bytes, changes meaning depending on command
 		byte* GetPacketBytes();							// returns the bytes to be transmitted
 		void ParameterFromInt(int i);
 
 		Command_Packet();
 
-	private: 
+	private:
 		static const byte COMMAND_START_CODE_1 = 0x55;	// Static byte to mark the beginning of a command packet	-	never changes
 		static const byte COMMAND_START_CODE_2 = 0xAA;	// Static byte to mark the beginning of a command packet	-	never changes
 		static const byte COMMAND_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
@@ -75,7 +75,7 @@ class Command_Packet
 		byte command[2];								// Command 2 bytes
 
 		word _CalculateChecksum();						// Checksum is calculated using byte addition
-		byte GetHighByte(word w);						
+		byte GetHighByte(word w);
 		byte GetLowByte(word w);
 };
 #ifndef __GNUC__
@@ -86,7 +86,7 @@ class Command_Packet
 #pragma region -= Response_Packet =-
 #endif  //__GNUC__
 /*
-	Response_Packet represents the returned data from the finger print scanner 
+	Response_Packet represents the returned data from the finger print scanner
 */
 class Response_Packet
 {
@@ -132,10 +132,10 @@ class Response_Packet
 		static const byte COMMAND_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)							-	theoretically never changes
 		int IntFromParameter();
 
-	private: 
+	private:
 		bool CheckParsing(byte b, byte propervalue, byte alternatevalue, const char* varname, bool UseSerialDebug);
 		word CalculateChecksum(byte* buffer, int length);
-		byte GetHighByte(word w);						
+		byte GetHighByte(word w);
 		byte GetLowByte(word w);
 };
 #ifndef __GNUC__
@@ -143,22 +143,27 @@ class Response_Packet
 #endif  //__GNUC__
 
 #ifndef __GNUC__
-#pragma region -= Data_Packet =- 
+#pragma region -= Data_Packet =-
 #endif  //__GNUC__
 // Data Mule packet for receiving large data(in 128 byte pieces) from the FPS
 // This class can only transmit one packet at a time
-//class Data_Packet
-//{
-//public:
-//	static int CheckSum;
-//	int PacketID;
-//	int ValidByteLength;
-//	byte Data[128];
-//	void StartNewPacket();
-//	bool IsLastPacket;
-//private:
-//	static int NextPacketID;
-//};
+class Data_Packet
+{
+public:
+    Data_Packet(byte* buffer, bool UseSerialDebug);
+    word checksum = 0;
+    static const byte DATA_START_CODE_1 = 0x5A;	// Static byte to mark the beginning of a data packet	-	never changes
+    static const byte DATA_START_CODE_2 = 0xA5;	// Static byte to mark the beginning of a data packet	-	never changes
+    static const byte DATA_DEVICE_ID_1 = 0x01;	// Device ID Byte 1 (lesser byte)							-	theoretically never changes
+    static const byte DATA_DEVICE_ID_2 = 0x00;	// Device ID Byte 2 (greater byte)
+private:
+	void GetData(byte* buffer, bool UseSerialDebug);
+	void GetLastData(byte* buffer, int length, bool UseSerialDebug);
+	bool CheckParsing(byte b, byte propervalue, byte alternatevalue, const char* varname, bool UseSerialDebug);
+	word CalculateChecksum(byte* buffer, int length);
+    byte GetHighByte(word w);
+    byte GetLowByte(word w);
+};
 #ifndef __GNUC__
 #pragma endregion
 #endif  //__GNUC__
@@ -169,9 +174,9 @@ class Response_Packet
 */
 class FPS_GT511C3
 {
- 
+
  public:
-	// Enables verbose debug output using hardware Serial 
+	// Enables verbose debug output using hardware Serial
 	bool UseSerialDebug;
 
 #ifndef __GNUC__
@@ -179,7 +184,7 @@ class FPS_GT511C3
 #endif  //__GNUC__
 	// Creates a new object to interface with the fingerprint scanner
 	FPS_GT511C3(uint8_t rx, uint8_t tx);
-	
+
 	// destructor
 	~FPS_GT511C3();
 #ifndef __GNUC__
@@ -202,7 +207,7 @@ class FPS_GT511C3
 	// Parameter: true turns on the backlight, false turns it off
 	// Returns: True if successful, false if not
 	bool SetLED(bool on);
-	
+
 	// Changes the baud rate of the connection
 	// Parameter: 9600 - 115200
 	// Returns: True if success, false if invalid baud
@@ -230,7 +235,7 @@ class FPS_GT511C3
 	int EnrollStart(int id);
 
 	// Gets the first scan of an enrollment
-	// Return: 
+	// Return:
 	//	0 - ACK
 	//	1 - Enroll Failed
 	//	2 - Bad finger
@@ -238,7 +243,7 @@ class FPS_GT511C3
 	int Enroll1();
 
 	// Gets the Second scan of an enrollment
-	// Return: 
+	// Return:
 	//	0 - ACK
 	//	1 - Enroll Failed
 	//	2 - Bad finger
@@ -247,7 +252,7 @@ class FPS_GT511C3
 
 	// Gets the Third scan of an enrollment
 	// Finishes Enrollment
-	// Return: 
+	// Return:
 	//	0 - ACK
 	//	1 - Enroll Failed
 	//	2 - Bad finger
@@ -315,7 +320,7 @@ class FPS_GT511C3
 	// Gets a template from the fps (498 bytes) in 4 Data_Packets
 	// Use StartDataDownload, and then GetNextDataPacket until done
 	// Parameter: 0-199 ID number
-	// Returns: 
+	// Returns:
 	//	0 - ACK Download starting
 	//	1 - Invalid position
 	//	2 - ID not used (no template to download
@@ -323,11 +328,11 @@ class FPS_GT511C3
 	// may revisit this if I find a need for it
 	//int GetTemplate(int id);
 
-	// Uploads a template to the fps 
+	// Uploads a template to the fps
 	// Parameter: the template (498 bytes)
 	// Parameter: the ID number to upload
 	// Parameter: Check for duplicate fingerprints already on fps
-	// Returns: 
+	// Returns:
 	//	0-199 - ID duplicated
 	//	200 - Uploaded ok (no duplicate if enabled)
 	//	201 - Invalid position
@@ -359,19 +364,10 @@ class FPS_GT511C3
 	void serialPrintHex(byte data);
 	void SendToSerial(byte data[], int length);
 
-	// resets the Data_Packet class, and gets ready to download
-	// Not implemented due to memory restrictions on the arduino
-	// may revisit this if I find a need for it
-	//void StartDataDownload();
-
-	// Returns the next data packet 
-	// Not implemented due to memory restrictions on the arduino
-	// may revisit this if I find a need for it
-	//Data_Packet GetNextDataPacket();
-
 private:
 	 void SendCommand(byte cmd[], int length);
 	 Response_Packet* GetResponse();
+	 void GetData(int length);
 	 uint8_t pin_RX,pin_TX;
 	 SoftwareSerial _serial;
 };


### PR DESCRIPTION
I have rewritten most of the code to implement some of the methods that were not implemented, mainly GetImage(), GetRawImage(), GetTemplate() and SetTemplate().

The change list goes like this:
* Implemented Data_Packet to send over HardwareSerial the data from the new implemented methods.
* The FPS initialization can now start comms whatever the actual baud rate is (useful if you changed it and didn't restart the FPS). Also can set the initial desired baud rate from the start.
* Implemented warnings about serial buffer overflow (will happen if you set a too high baud rate).
* Implemented an experimental patch in GetImage(). Whatever the GT-511C3 documentation says about this is wrong or outdated. You can use the patch by including a true in the method call. By default it will use the documented method.
* Rewrite of variables (using fixed size ones), and memory optimizations.

Tested all methods with Arduino Uno and GT-511C3 FPS. Any existing code using this library shouldn't have any problem updating to this version, since the method declarations are mostly unmodified.

If this is accepted, any feedback about other FPS devices, implementations with Arduino, bugs, etc., would be very helpful.